### PR TITLE
made sure all data structures can be reprinted with new settings, without side effects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,4 +32,7 @@ test-select:
 	node ./bin/keen-query.js 'cta->select(page.location.type)->relTime(30_minutes)->interval(m)'
 	node ./bin/keen-query.js 'cta->select(page.location.type)->relTime(30_minutes)->interval(m)->group(user.isStaff)'
 
+test-reusability:
+	mocha test/reusability.test.js
+
 test: test-query test-ratio test-reduce test-select

--- a/lib/aggregators/concat.js
+++ b/lib/aggregators/concat.js
@@ -34,3 +34,15 @@ module.exports = function () {
 	}
 	this._table = table;
 }
+
+
+
+	// concat (table) {
+	// 	throw 'TODO concatenating tables'
+	// 	if (this.dimension !== table.dimension || this.timeHeadingsLocation !== table.timeHeadingsLocation) {
+	// 		throw 'tables have incompatible data structure';
+	// 	}
+	// 	if (typeof this.timeHeadingsLocation !== 'undefined' && this.axes[this.timeHeadingsLocation].length !== table.axes[table.timeHeadingsLocation].length) {
+	// 		throw 'tables have incompatible date ranges';
+	// 	}
+	// }

--- a/lib/aggregators/index.js
+++ b/lib/aggregators/index.js
@@ -10,11 +10,13 @@ const aggregators = {
 
 class Aggregator {
 	constructor (conf) {
-		const base = require('../index');
-		this.queries = conf.body.map(base.build);
-		this.aggregator = aggregators[conf.aggregator.substr(1)];
-		this._printer = conf.print;
-		this._postProcessing = conf.postProcessing;
+		if (conf) {
+			const base = require('../index');
+			this.queries = conf.body.map(base.build);
+			this.aggregator = aggregators[conf.aggregator.substr(1)];
+			this._printer = conf.print;
+			this._postProcessing = conf.postProcessing;
+		}
 	}
 
 	print (style) {
@@ -43,11 +45,31 @@ class Aggregator {
 			})
 	}
 
+	clone (withData) {
+		const aggregator = new Aggregator();
+		aggregator.queries = this.queries.map(kq => kq.clone(withData))
+		aggregator.aggregator = this.aggregators;
+		aggregator._printer = this._print;
+		aggregator._postProcessing = this._postProcessing && this._postProcessing.slice().map(f => Object.assign({}, f));
+		if (withData) {
+			aggregator._table = this.getTable().clone();
+		}
+		return aggregator;
+	}
+
 	getTable () {
 		return this._table;
 	}
 }
 
+
+['reduce', 'round'].forEach(method => {
+	Aggregator.prototype[method] = function () {
+		const aggregator = this.clone(true);
+		aggregator._table = aggregator.getTable()[method].apply(aggregator.getTable(), [].slice.call(arguments))
+		return aggregator;
+	}
+});
 
 module.exports = function (conf) {
 	return new Aggregator(conf);

--- a/lib/keen-query.js
+++ b/lib/keen-query.js
@@ -3,6 +3,7 @@ require('isomorphic-fetch');
 const querystring = require('querystring');
 const utils = require('./utils');
 const tabulate = require('./tabulate');
+const Table = require('./table');
 const URL = require('url');
 const moment = require('moment');
 
@@ -21,7 +22,9 @@ const forcedQueries = [];
 class KeenQuery {
 	constructor (event) {
 		this.dimensions = [];
+		this.groupedBy = [];
 		if (typeof event === 'object') {
+			throw 'THIS DOESN"T work any more'
 			this.query = event.query || {};
 			this.extraction = event.extraction;
 			this.filters = event.filters;
@@ -38,85 +41,89 @@ class KeenQuery {
 	// chainable extraction methods
 	count (prop) {
 		if (prop) {
-			this.setExtraction('count_unique')
+			this._setExtraction('count_unique')
 			this.query.target_property = prop;
 		} else {
-			this.setExtraction('count')
+			this._setExtraction('count')
 		}
 		return this;
 	}
 
 	min (prop) {
-		this.setExtraction('minimum');
+		this._setExtraction('minimum');
 		this.query.target_property = prop;
 		return this;
 	}
 
 	max (prop) {
-		this.setExtraction('maximum');
+		this._setExtraction('maximum');
 		this.query.target_property = prop;
 		return this;
 	}
 
 	sum (prop) {
-		this.setExtraction('sum');
+		this._setExtraction('sum');
 		this.query.target_property = prop;
 		return this;
 	}
 
 	avg (prop) {
-		this.setExtraction('average');
+		this._setExtraction('average');
 		this.query.target_property = prop;
 		return this;
 	}
 
 	med (prop) {
-		this.setExtraction('median');
+		this._setExtraction('median');
 		this.query.target_property = prop;
 		return this;
 	}
 
 	pct (prop, pct) {
-		this.setExtraction('percentile');
+		this._setExtraction('percentile');
 		this.query.target_property = prop;
 		this.query.percentile = pct;
 		return this;
 	}
 
 	select (prop) {
-		this.setExtraction('select_unique');
+		this._setExtraction('select_unique');
 		this.query.target_property = prop;
 		return this;
 	}
 
 	raw () {
-		this.forcedQueries = [];
-		return this;
+		const instance = this._getInstance();
+		instance.forcedQueries = [];
+		return instance;
 	}
 
 	interval(interval) {
-		this.dimensions.unshift('timeframe');
-		this.intervalUnit = mappings.intervalUnits[interval] || interval;
-		this.query.interval = mappings.intervals[this.intervalUnit];
+		const instance = this._getInstance();
+		instance.dimensions.unshift('timeframe');
+		instance.intervalUnit = mappings.intervalUnits[interval] || interval;
+		instance.query.interval = mappings.intervals[instance.intervalUnit];
 
-		this.timeframe = this.timeframe || 'this_14_days';
-		return this;
+		instance.timeframe = instance.timeframe || 'this_14_days';
+		return instance;
 	}
 
 	absTime (start, end, interval) {
-		this.timeframe = JSON.stringify({
+		const instance = this._getInstance();
+		instance.timeframe = JSON.stringify({
 			start: typeof start === 'string' ? start : start.toISOString(),
 			end: typeof end === 'string' ? end : end.toISOString()
 		});
 
 		if (interval) {
-			this.interval(interval);
+			instance.interval(interval);
 		}
 
-		return this;
+		return instance;
 	}
 
 	relTime(time, interval) {
+		const instance = this._getInstance();
 		if (time) {
 			if (parseInt(time, 10) === Number(time)) {
 				time = time + '_days';
@@ -124,53 +131,31 @@ class KeenQuery {
 		} else {
 			time = '14_days';
 		}
-		this.timeframe = (time.indexOf('this_') === 0 || time.indexOf('previous_') === 0) ? time : 'this_' + time;
+		instance.timeframe = (time.indexOf('this_') === 0 || time.indexOf('previous_') === 0) ? time : 'this_' + time;
 
 		if (interval) {
-			this.interval(interval);
+			instance.interval(interval);
 		}
 
-		return this;
+		return instance;
 	}
 
 	time(time, interval) {
 		return this.relTime(time, interval);
 	}
 
-	prev () {
-		this.timeframe = this.timeframe || 'this_14_days';
-		if (this.timeframe.indexOf('this_') === 0) {
-			this.timeframe = this.timeframe.replace('this_', 'previous_');
-		} else {
-			const tf = JSON.parse(this.timeframe);
-			const duration = moment(tf.end).diff(moment(tf.start));
-			this.timeframe = JSON.stringify({
-				start: moment(tf.start).subtract(duration, 'milliseconds').toISOString(),
-				end: typeof tf.start === 'string' ? tf.start : tf.start.toISOString()
-			});
-		}
-		return this;
-	}
-
 	group () {
-		this.groupedBy = this.groupedBy || [];
-		this.groupedBy = this.groupedBy.concat([].slice.call(arguments));
-		this.dimensions = this.dimensions.concat([].slice.call(arguments));
-		return this;
-	}
-
-	flip () {
-		this.groupedBy = this.groupedBy && this.groupedBy.reverse();
-
-		if (this.query.interval) {
-			this.flipTable = true;
-		}
-		return this;
+		const instance = this._getInstance();
+		instance.groupedBy = instance.groupedBy || [];
+		instance.groupedBy = instance.groupedBy.concat([].slice.call(arguments));
+		instance.dimensions = instance.dimensions.concat([].slice.call(arguments));
+		return instance;
 	}
 
 	filter (filter) {
-		this.filters.push(filter)
-		return this;
+		const instance = this._getInstance();
+		instance.filters.push(typeof filter === 'string' ? parser.parseFilter(filter) : filter)
+		return instance;
 	}
 
 	toString () {
@@ -201,12 +186,19 @@ class KeenQuery {
 
 		return str;
 	}
-	setExtraction (name) {
 
+	_setExtraction (name) {
 		if (this.extraction) {
 			throw new Error(`Cannot run ${name} extraction, extraction type already set to ${this.query.extraction}`);
 		}
 		this.extraction = name
+	}
+
+	_getInstance () {
+		if (this._data) {
+			return this.clone();
+		}
+		return this;
 	}
 
 	generateKeenUrl () {
@@ -241,7 +233,6 @@ class KeenQuery {
 		if (!style && this._printer) {
 			return this.print.call(this, this._printer);
 		}
-
 		this.forcedQueries.forEach(q => {
 			q.apply(this);
 		});
@@ -266,24 +257,42 @@ class KeenQuery {
 			.then(res => res.json())
 			.then(data => {
 				this._data = data;
-				this._table = this.tabulate(data);
+				this._table = this._tabulate(data);
 				if (this._postProcessing) {
 					this._postProcessing.forEach(opts => {
 						this._table = this.getTable()[opts.func].apply(this.getTable(), opts.params);
 					})
 				}
 				return printers.call(this, style);
-			})
-			.catch(err => console.log(err))
+			});
 	}
 
-	tabulate () {
+	_tabulate () {
 		return tabulate.apply(this, [].slice.call(arguments))
 	}
 
 
 	getTable () {
 		return this._table;
+	}
+
+	clone (withData) {
+		const kq = new KeenQuery();
+		kq.query = Object.assign({}, this.query);
+		kq.extraction = this.extraction;
+		kq.filters = this.filters.slice().map(f => Object.assign({}, f));
+		kq.forcedQueries = this.forcedQueries && this.forcedQueries.slice().map(f => Object.assign({}, f));
+		kq._postProcessing = this._postProcessing && this._postProcessing.slice().map(f => Object.assign({}, f));
+		kq.timeframe = typeof this.timeframe === 'string' ? this.timeframe : Object.assign({}, this.timeframe);
+		kq.dimensions = this.dimensions.slice();
+		kq.intervalUnit = this.intervalUnit;
+		kq.groupedBy = this.groupedBy.slice();
+		kq._printer = this._printer;
+		if (withData) {
+			kq._data = this._data;
+			kq._table = this.getTable().clone();
+		}
+		return kq;
 	}
 
 	static fromUrl (url) {
@@ -318,4 +327,14 @@ class KeenQuery {
 	}
 
 }
+
+// mixin all the table methods
+['reduce', 'round'].forEach(method => {
+	KeenQuery.prototype[method] = function () {
+		const kq = this.clone(true);
+		kq._table = kq.getTable()[method].apply(kq.getTable(), [].slice.call(arguments))
+		return kq;
+	}
+});
+
 module.exports = KeenQuery;

--- a/lib/post-processing.js
+++ b/lib/post-processing.js
@@ -93,10 +93,10 @@ module.exports.reduce = function (strategy, dimension) {
 		}
 		axes.pop();
 	}
-	return new Table(Object.assign({}, table, {
+	return table.clone({
 		axes,
 		data: buckets
-	}))
+	})
 }
 
 module.exports.reduceStrategies = strategiesMap;

--- a/lib/printers/index.js
+++ b/lib/printers/index.js
@@ -1,9 +1,9 @@
 const printers = {
-	raw: function (data) {
+	raw: function () {
 		return this._data;
 	},
 
-	json: function (data) {
+	json: function () {
 		return this.getTable().humanize();
 	},
 

--- a/lib/table.js
+++ b/lib/table.js
@@ -97,19 +97,9 @@ class Table {
 			})
 		};
 
-		return new Table(Object.assign({}, this, {
+		return this.clone({
 			axes: axes
-		}));
-	}
-
-	concat (table) {
-		throw 'TODO concatenating tables'
-		if (this.dimension !== table.dimension || this.timeHeadingsLocation !== table.timeHeadingsLocation) {
-			throw 'tables have incompatible data structure';
-		}
-		if (typeof this.timeHeadingsLocation !== 'undefined' && this.axes[this.timeHeadingsLocation].length !== table.axes[table.timeHeadingsLocation].length) {
-			throw 'tables have incompatible date ranges';
-		}
+		});
 	}
 
 	// converts a table to a the sort of data structure graphing libraries typically require
@@ -174,11 +164,15 @@ class Table {
 
 	// returns a new table with values rounded to n decimal points
 	round (points) {
-		return new Table(Object.assign({}, this, {
+		return this.clone({
 			data: this.cellIterator(val => {
 				return Math.round(val * Math.pow(10, points)) / Math.pow(10, points);
 			})
-		}));
+		});
+	}
+
+	clone (overrides) {
+		return new Table(Object.assign({}, this, overrides || {}));
 	}
 
 	// swaps two dimensions of the table
@@ -222,7 +216,7 @@ class Table {
   		axes.splice(b, 1, tmp);
   	}
 
-	  return new Table(Object.assign({}, this, {
+	  return this.clone({
 			axes: axes,
 			data: Object.keys(this.data).reduce((map, k) => {
 		    const coords = k.split(',');
@@ -238,7 +232,9 @@ class Table {
 			  map[coords.join(',')] = this.data[k];
 			  return map;
 		  }, {})
-		}));
+		});
 	}
+
+
 }
 module.exports = Table;

--- a/package.json
+++ b/package.json
@@ -26,5 +26,9 @@
   "bugs": {
     "url": "https://github.com/Financial-Times/keen-query/issues"
   },
-  "homepage": "https://github.com/Financial-Times/keen-query#readme"
+  "homepage": "https://github.com/Financial-Times/keen-query#readme",
+  "devDependencies": {
+    "chai": "^3.4.1",
+    "mocha": "^2.4.2"
+  }
 }

--- a/test/reusability.test.js
+++ b/test/reusability.test.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const KeenQuery = require('../lib/index.js');
+const expect = require('chai').expect;
+describe('reusability of keen-query objects', function () {
+	let baseResult;
+	let kq;
+
+	before(function (done) {
+		this.timeout(20000);
+		kq = KeenQuery.build('cta->count()->relTime(1)->interval(h)');
+		return kq.print('raw')
+			.then(res => {
+				baseResult = res;
+				done();
+			})
+	});
+
+	it('should reuse data when printing again', function () {
+		return kq.print('raw')
+			.then(res => {
+				expect(res).to.equal(baseResult)
+			})
+	});
+
+	it('should not mutate original data when adding some condition', function () {
+		const altered = kq.filter('user.uuid');
+		expect(altered).to.not.equal(kq);
+		return Promise.all([
+			altered.print('json'),
+			kq.print('json')
+		]).then(res => {
+			expect(res[0]).to.not.deep.equal(res[1]);
+		})
+	})
+
+	it('should not mutate original data when reducing', function () {
+		const altered = kq.reduce('avg');
+		expect(altered).to.not.equal(kq);
+		return Promise.all([
+			altered.print('json'),
+			kq.print('json')
+		]).then(res => {
+			expect(res[0]).to.not.deep.equal(res[1]);
+		})
+	})
+	describe('ratio', function () {
+		let ratio;
+		before(function (done) {
+			ratio = KeenQuery.build('@ratio(cta->count(),cta->count(user.uuid))->relTime(1)->interval(h)');
+			return ratio.print('raw')
+				.then(res => {
+					done();
+				})
+		});
+		it('should not mutate original ratio data when reducing', function () {
+			return Promise.all([
+				ratio.reduce('avg').print('json'),
+				ratio.print('json')
+			])
+				.then(res => {
+					expect(res[0]).to.not.deep.equal(res[1]);
+				})
+		});
+	});
+
+
+
+
+
+
+
+
+
+// 'cta->count()->filter(user.uuid)->group(page.location.type,user.isStaff)->relTime(3)->round()';
+
+})


### PR DESCRIPTION
This will allow something like

```js
// build the base query object from alias and print
const baseKq = KeenQuery.build(alias.query)
 .time(alias.time)
baseKq.print(alias.printer)

// Then later in response to user changing an option
// (these will leave baseKq unaltered, and will only refetch data if an action which woudl change the underlying data is applied)
const alteredKq = baseKq.relTime(options.timeframe)
alteredKq.print(options.printer)

```
@adambraimbridge 