### PR TITLE
added sum aggregator

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,8 @@ Some methods expect a dimension to be specified e.g to choose between taking an 
 
 These combine multiple keen-queries using a perdefined rule. They follow the syntax `@agregatorName(comma separated list of queries)`. So far they are not available In the JS API, and include:
 
-- `@ratio` - Given two queries returning results with identical structure, it returns a new table where the values are the result of dividing the value in the first table with its corresponding value n the second
+- `@ratio` - Given two queries returning results with identical structure, it returns a new table where the values are the result of dividing the value in the first table with its corresponding value in the second
+- `@sum` - Given two queries returning results with identical structure, it returns a new table where the values are the result of adding the value in the first table to its corresponding value in the second
 - `@concat` - **TODO (please request)** Given n queries returning results with similar structure, it combines them into a single table by concatenating the columns of each table
 - `@funnel` - **TODO**
 

--- a/lib/aggregators/index.js
+++ b/lib/aggregators/index.js
@@ -5,7 +5,8 @@ const printers = require('../printers');
 
 const aggregators = {
 	concat: require('./concat'),
-	ratio: require('./ratio')
+	ratio: require('./ratio'),
+	sum: require('./sum'),
 };
 
 class Aggregator {

--- a/lib/aggregators/sum.js
+++ b/lib/aggregators/sum.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const printers = require('../printers');
+const Table = require('../table');
+function calculateSum (table1, table2) {
+	if (table1.dimension !== table2.dimension) {
+		throw 'Tables are incompatible - wrong dimension';
+	}
+
+	if (table1.size.join(',') !== table2.size.join(',')) {
+		throw 'Tables are incompatible - different number of rows/columns';
+	}
+
+	const data = table1.dimension ? table1.cellIterator((value, coords) => value + table2.data[coords]) : table1.data + table2.data;
+	return new Table(Object.assign({}, table1, {
+		data: data
+	}));
+}
+
+module.exports = function () {
+	this._table = calculateSum(this.queries[0].getTable(), this.queries[1].getTable())
+}


### PR DESCRIPTION
This should prevent us from having to worry about a renamed event/property mucking up reporting as we can sum both. Could add max and min ones too, though I don't think there's much call for that 

e.g. `@sum(page:view->count(),dwell->count())`

@adambraimbridge