### PR TITLE
Generate keen url — now with new explorer flavour

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,4 +37,7 @@ test-select:
 test-reusability:
 	mocha test/reusability.test.js
 
-test: test-query test-ratio test-reduce test-select test-reusability
+test-keen-urls:
+	mocha test/keen-urls.test.js
+
+test: test-query test-ratio test-reduce test-select test-reusability test-keen-urls

--- a/lib/aggregators/index.js
+++ b/lib/aggregators/index.js
@@ -30,7 +30,7 @@ class Aggregator {
 
 		style = style || this._printer;
 
-		if (style === 'qs' || style === 'qo' || style === 'url' || style === 'explorer-url') {
+		if (style === 'qs' || style === 'qo' || style === 'url') {
 			return Promise.all(this.queries.map(q => q.print(style)));
 		}
 
@@ -92,11 +92,3 @@ module.exports.define = function (name, func) {
 		return aggregator;
 	}
 });
-
-
-
-
-
-
-
-

--- a/lib/aggregators/index.js
+++ b/lib/aggregators/index.js
@@ -30,7 +30,7 @@ class Aggregator {
 
 		style = style || this._printer;
 
-		if (style === 'qs' || style === 'qo' || style === 'url') {
+		if (style === 'qs' || style === 'qo' || style === 'url' || style === 'explorer-url') {
 			return Promise.all(this.queries.map(q => q.print(style)));
 		}
 
@@ -54,8 +54,8 @@ class Aggregator {
 		return `@${this.aggregatorName}(${this.queries.map(q => q.toString()).join(',')})`;
 	}
 
-	generateKeenUrl(base) {
-		return this.queries.map(q => q.generateKeenUrl(base))
+	generateKeenUrl(format) {
+		return this.queries.map(q => q.generateKeenUrl(format))
 	}
 
 	clone (withData) {
@@ -86,7 +86,7 @@ module.exports.define = function (name, func) {
 };
 
 ['raw', 'interval', 'absTime', 'relTime', 'group', 'filter', 'tidy'].forEach(method => {
-	Aggregator.prototype[method] = function () {
+	Aggregator.prototype[method] = () => {
 		const aggregator = this.clone();
 		aggregator.queries = aggregator.queries.map(q => q[method].apply(q, [].slice.call(arguments)))
 		return aggregator;

--- a/lib/keen-query.js
+++ b/lib/keen-query.js
@@ -228,9 +228,15 @@ class KeenQuery {
 	}
 
 	// format can be `api` or `explorer`
-	generateKeenUrl (format) {
+	generateKeenUrl (format, base) {
 		format = typeof format === 'undefined' ? 'api' : format
+		if (format === 'api') {
+			base = base || `https://api.keen.io/3.0/projects/${configContainer.KEEN_PROJECT_ID}/queries/${this.extraction}?api_key=${configContainer.KEEN_READ_KEY}&`
+		} else {
+			base = base || ''
+		}
 
+		let parameterString = ''
 		let properties = {
 			analysis_type: this.extraction,
 			target_property: this.query.target_property,
@@ -263,7 +269,7 @@ class KeenQuery {
 				explorerParts = explorerParts.concat(filterParts)
 			}
 
-			return `/data/explorer?${explorerParts.join('&')}`;
+			parameterString = explorerParts.join('&')
 		}
 		else {
 			if (this.filters.length) {
@@ -274,9 +280,10 @@ class KeenQuery {
 				.filter(p => properties[p] && (typeof properties[p] === 'object' ? properties[p].length : properties[p]))
 				.map(p => `${p}=${encodeURIComponent(properties[p])}`))
 
-			const base = `https://api.keen.io/3.0/projects/${configContainer.KEEN_PROJECT_ID}/queries/${this.extraction}?api_key=${configContainer.KEEN_READ_KEY}&`;
-			return `${base}${apiParts.join('&')}`;
+			parameterString = apiParts.join('&')
 		}
+
+		return `${base}${parameterString}`;
 	}
 
 	getQueryObject (type) {

--- a/lib/keen-query.js
+++ b/lib/keen-query.js
@@ -233,6 +233,7 @@ class KeenQuery {
 
 		let properties = {
 			analysis_type: this.extraction,
+			target_property: this.query.target_property,
 			event_collection: this.query.event_collection,
 			interval: this.query.interval,
 			timeframe: this.timeframe,

--- a/lib/keen-query.js
+++ b/lib/keen-query.js
@@ -227,33 +227,6 @@ class KeenQuery {
 		return this;
 	}
 
-	generateKeenUrlXXXXXXX (base) {
-		base = typeof base === 'undefined' ? `https://api.keen.io/3.0/projects/${configContainer.KEEN_PROJECT_ID}/queries/${this.extraction}?api_key=${configContainer.KEEN_READ_KEY}`: base;
-
-		const parts = [base];
-		const filters = this.filters.slice();
-
-		if (this.groupedBy.length) {
-			parts.push(`group_by=${this.groupedBy.length === 1 ? this.groupedBy[0] : encodeURIComponent(JSON.stringify(this.groupedBy))}`);
-
-			if (this.excludeNulls) {
-				this.groupedBy.forEach(prop => {
-					filters.push({
-						property_name: prop,
-						operator: 'exists',
-						property_value: true
-					});
-				})
-			}
-		}
-
-		return parts.concat([
-			`${querystring.stringify(this.query)}`,
-			`filters=${encodeURIComponent(JSON.stringify(filters))}`,
-			`timeframe=${this.timeframe}`
-		]).join('&');
-	}
-
 	// format can be `api` or `explorer`
 	generateKeenUrl (format) {
 		format = typeof format === 'undefined' ? 'api' : format
@@ -267,8 +240,9 @@ class KeenQuery {
 		}
 
 		// Todo: Move this excludeNulls logic outside of generateKeenUrl()
-		if (!this.filters) this.filters = [];
 		if (this.groupedBy.length && this.excludeNulls) {
+			if (!this.filters) this.filters = []
+
 			this.groupedBy.forEach(prop => {
 				filters.push({
 					property_name: prop,
@@ -291,14 +265,13 @@ class KeenQuery {
 			return `/data/explorer?${explorerParts.join('&')}`;
 		}
 		else {
+			if (this.filters.length) {
+				properties.filters = JSON.stringify(this.filters)
+			}
+
 			let apiParts = [].concat(Object.keys(properties)
 				.filter(p => properties[p] && (typeof properties[p] === 'object' ? properties[p].length : properties[p]))
 				.map(p => `${p}=${encodeURIComponent(properties[p])}`))
-
-			const filterParts = this.filters.map((f, i) => Object.keys(f).map(p => `filters[${i}]=${encodeURIComponent(f[p])}`))[0];
-			if (filterParts && filterParts.length) {
-				apiParts = apiParts.concat(filterParts)
-			}
 
 			const base = `https://api.keen.io/3.0/projects/${configContainer.KEEN_PROJECT_ID}/queries/${this.extraction}?api_key=${configContainer.KEEN_READ_KEY}`;
 			return `${base}${apiParts.join('&')}`;

--- a/lib/keen-query.js
+++ b/lib/keen-query.js
@@ -251,7 +251,7 @@ class KeenQuery {
 			if (!this.filters) this.filters = []
 
 			this.groupedBy.forEach(prop => {
-				filters.push({
+				this.filters.push({
 					property_name: prop,
 					operator: 'exists',
 					property_value: true

--- a/lib/keen-query.js
+++ b/lib/keen-query.js
@@ -227,7 +227,7 @@ class KeenQuery {
 		return this;
 	}
 
-	generateKeenUrl (base) {
+	generateKeenUrlXXXXXXX (base) {
 		base = typeof base === 'undefined' ? `https://api.keen.io/3.0/projects/${configContainer.KEEN_PROJECT_ID}/queries/${this.extraction}?api_key=${configContainer.KEEN_READ_KEY}`: base;
 
 		const parts = [base];
@@ -252,7 +252,57 @@ class KeenQuery {
 			`filters=${encodeURIComponent(JSON.stringify(filters))}`,
 			`timeframe=${this.timeframe}`
 		]).join('&');
+	}
 
+	// format can be `api` or `explorer`
+	generateKeenUrl (format) {
+		format = typeof format === 'undefined' ? 'api' : format
+
+		let properties = {
+			analysis_type: this.extraction,
+			event_collection: this.query.event_collection,
+			interval: this.query.interval,
+			timeframe: this.timeframe,
+			group_by: this.groupedBy
+		}
+
+		// Todo: Move this excludeNulls logic outside of generateKeenUrl()
+		if (!this.filters) this.filters = [];
+		if (this.groupedBy.length && this.excludeNulls) {
+			this.groupedBy.forEach(prop => {
+				filters.push({
+					property_name: prop,
+					operator: 'exists',
+					property_value: true
+				});
+			})
+		}
+
+		if (format === 'explorer') {
+			let explorerParts = [].concat(Object.keys(properties)
+				.filter(p => properties[p] && (typeof properties[p] === 'object' ? properties[p].length : properties[p]))
+				.map(p => `query[${p}]=${encodeURIComponent(properties[p])}`))
+
+			const filterParts = this.filters.map((f, i) => Object.keys(f).map(p => `query[filters][${i}]=${encodeURIComponent(f[p])}`))[0];
+			if (filterParts && filterParts.length) {
+				explorerParts = explorerParts.concat(filterParts)
+			}
+
+			return `/data/explorer?${explorerParts.join('&')}`;
+		}
+		else {
+			let apiParts = [].concat(Object.keys(properties)
+				.filter(p => properties[p] && (typeof properties[p] === 'object' ? properties[p].length : properties[p]))
+				.map(p => `${p}=${encodeURIComponent(properties[p])}`))
+
+			const filterParts = this.filters.map((f, i) => Object.keys(f).map(p => `filters[${i}]=${encodeURIComponent(f[p])}`))[0];
+			if (filterParts && filterParts.length) {
+				apiParts = apiParts.concat(filterParts)
+			}
+
+			const base = `https://api.keen.io/3.0/projects/${configContainer.KEEN_PROJECT_ID}/queries/${this.extraction}?api_key=${configContainer.KEEN_READ_KEY}`;
+			return `${base}${apiParts.join('&')}`;
+		}
 	}
 
 	getQueryObject (type) {
@@ -300,6 +350,11 @@ class KeenQuery {
 		if (style === 'url') {
 			return Promise.resolve(url);
 		}
+
+		if (style === 'explorer-url') {
+			return Promise.resolve(this.generateKeenUrl('explorer'));
+		}
+
 		if (this._data) {
 			return Promise.resolve(printers.call(this, style))
 		}

--- a/lib/keen-query.js
+++ b/lib/keen-query.js
@@ -273,7 +273,7 @@ class KeenQuery {
 				.filter(p => properties[p] && (typeof properties[p] === 'object' ? properties[p].length : properties[p]))
 				.map(p => `${p}=${encodeURIComponent(properties[p])}`))
 
-			const base = `https://api.keen.io/3.0/projects/${configContainer.KEEN_PROJECT_ID}/queries/${this.extraction}?api_key=${configContainer.KEEN_READ_KEY}`;
+			const base = `https://api.keen.io/3.0/projects/${configContainer.KEEN_PROJECT_ID}/queries/${this.extraction}?api_key=${configContainer.KEEN_READ_KEY}&`;
 			return `${base}${apiParts.join('&')}`;
 		}
 	}

--- a/lib/keen-query.js
+++ b/lib/keen-query.js
@@ -228,7 +228,7 @@ class KeenQuery {
 	}
 
 	// format can be `api` or `explorer`
-	generateKeenUrl (format, base) {
+	generateKeenUrl (base, format) {
 		format = typeof format === 'undefined' ? 'api' : format
 		if (format === 'api') {
 			base = base || `https://api.keen.io/3.0/projects/${configContainer.KEEN_PROJECT_ID}/queries/${this.extraction}?api_key=${configContainer.KEEN_READ_KEY}&`

--- a/test/keen-urls.test.js
+++ b/test/keen-urls.test.js
@@ -3,7 +3,7 @@
 const KeenQuery = require('../lib/index.js')
 const expect = require('chai').expect
 
-/* Keen explorer */
+/* Keen API */
 describe('generating URLS for keen-query: API', () => {
 
 	it('should have api-compatible urls for basic queries', () => {
@@ -14,95 +14,95 @@ describe('generating URLS for keen-query: API', () => {
 			})
 	})
 
-// 	it('should have api-compatible urls for timeframed queries', () => {
-// 		const kq = KeenQuery.build('page:view->count()')
-// 			.relTime('this_1_years')
+	it('should have api-compatible urls for timeframed queries', () => {
+		const kq = KeenQuery.build('page:view->count()')
+			.relTime('this_1_years')
 
-// 		return kq.print('url')
-// 			.then(res => {
-// 				expect(res).to.contain('&timeframe=this_1_years')
-// 			})
-// 	})
+		return kq.print('url')
+			.then(res => {
+				expect(res).to.contain('&timeframe=this_1_years')
+			})
+	})
 
-// 	it('should have api-compatible urls for intervalled queries', () => {
-// 		const kq = KeenQuery.build('page:view->count()')
-// 			.interval('month')
+	it('should have api-compatible urls for intervalled queries', () => {
+		const kq = KeenQuery.build('page:view->count()')
+			.interval('month')
 
-// 		return kq.print('url')
-// 			.then(res => {
-// 				expect(res).to.contain('&interval=monthly')
-// 			})
-// 	})
+		return kq.print('url')
+			.then(res => {
+				expect(res).to.contain('&interval=monthly')
+			})
+	})
 
-// 	it('should have api-compatible urls for filtered queries', () => {
-// 		const kq = KeenQuery.build('page:view->count()')
-// 			.filter('user.uuid')
+	it('should have api-compatible urls for filtered queries', () => {
+		const kq = KeenQuery.build('page:view->count()')
+			.filter('user.uuid')
 
-// 		return kq.print('url')
-// 			.then(res => {
-// 				expect(res).to.contain('&filters=%5B%7B%22property_name%22%3A%22user.uuid%22%2C%22operator%22%3A%22exists%22%2C%22property_value%22%3Atrue%7D%5D')
-// 			})
-// 	})
+		return kq.print('url')
+			.then(res => {
+				expect(res).to.contain('&filters=%5B%7B%22property_name%22%3A%22user.uuid%22%2C%22operator%22%3A%22exists%22%2C%22property_value%22%3Atrue%7D%5D')
+			})
+	})
 
-// 	it('should have api-compatible urls for grouped queries', () => {
-// 		const kq = KeenQuery.build('page:view->count()')
-// 			.group('user.geo.continent')
+	it('should have api-compatible urls for grouped queries', () => {
+		const kq = KeenQuery.build('page:view->count()')
+			.group('user.geo.continent')
 
-// 		return kq.print('url')
-// 			.then(res => {
-// 				expect(res).to.contain('&group_by=user.geo.continent')
-// 			})
-// 	})
+		return kq.print('url')
+			.then(res => {
+				expect(res).to.contain('&group_by=user.geo.continent')
+			})
+	})
 })
 
 /* Keen explorer */
-// describe('generating URLS for keen-query: Explorer', () => {
+describe('generating URLS for keen-query: Explorer', () => {
 
-// 	it('should have explorer-compatible urls for basic queries', () => {
-// 		const kq = KeenQuery.build('page:view->count()')
-// 		return kq.print('explorer-url')
-// 			.then(res => {
-// 				expect(res).to.contain('query[analysis_type]=count&query[event_collection]=page%3Aview')
-// 			})
-// 	})
+	it('should have explorer-compatible urls for basic queries', () => {
+		const kq = KeenQuery.build('page:view->count()')
+		return kq.print('explorer-url')
+			.then(res => {
+				expect(res).to.contain('query[analysis_type]=count&query[event_collection]=page%3Aview')
+			})
+	})
 
-// 	it('should have explorer-compatible urls for timeframed queries', () => {
-// 		const kq = KeenQuery.build('page:view->count()')
-// 			.relTime('this_1_years')
+	it('should have explorer-compatible urls for timeframed queries', () => {
+		const kq = KeenQuery.build('page:view->count()')
+			.relTime('this_1_years')
 
-// 		return kq.print('explorer-url')
-// 			.then(res => {
-// 				expect(res).to.contain('&query[timeframe]=this_1_years')
-// 			})
-// 	})
+		return kq.print('explorer-url')
+			.then(res => {
+				expect(res).to.contain('&query[timeframe]=this_1_years')
+			})
+	})
 
-// 	it('should have explorer-compatible urls for intervalled queries', () => {
-// 		const kq = KeenQuery.build('page:view->count()')
-// 			.interval('month')
+	it('should have explorer-compatible urls for intervalled queries', () => {
+		const kq = KeenQuery.build('page:view->count()')
+			.interval('month')
 
-// 		return kq.print('explorer-url')
-// 			.then(res => {
-// 				expect(res).to.contain('&query[interval]=monthly')
-// 			})
-// 	})
+		return kq.print('explorer-url')
+			.then(res => {
+				expect(res).to.contain('&query[interval]=monthly')
+			})
+	})
 
-// 	it('should have explorer-compatible urls for filtered queries', () => {
-// 		const kq = KeenQuery.build('page:view->count()')
-// 			.filter('user.uuid')
+	it('should have explorer-compatible urls for filtered queries', () => {
+		const kq = KeenQuery.build('page:view->count()')
+			.filter('user.uuid')
 
-// 		return kq.print('explorer-url')
-// 			.then(res => {
-// 				expect(res).to.contain('&query[filters][0]=user.uuid&query[filters][0]=exists&query[filters][0]=true')
-// 			})
-// 	})
+		return kq.print('explorer-url')
+			.then(res => {
+				expect(res).to.contain('&query[filters][0]=user.uuid&query[filters][0]=exists&query[filters][0]=true')
+			})
+	})
 
-// 	it('should have explorer-compatible urls for grouped queries', () => {
-// 		const kq = KeenQuery.build('page:view->count()')
-// 			.group('user.geo.continent')
+	it('should have explorer-compatible urls for grouped queries', () => {
+		const kq = KeenQuery.build('page:view->count()')
+			.group('user.geo.continent')
 
-// 		return kq.print('explorer-url')
-// 			.then(res => {
-// 				expect(res).to.contain('&query[group_by]=user.geo.continent')
-// 			})
-// 	})
-// })
+		return kq.print('explorer-url')
+			.then(res => {
+				expect(res).to.contain('&query[group_by]=user.geo.continent')
+			})
+	})
+})

--- a/test/keen-urls.test.js
+++ b/test/keen-urls.test.js
@@ -10,7 +10,7 @@ describe('generating URLS for keen-query: API', () => {
 		const kq = KeenQuery.build('page:view->count()')
 		return kq.print('url')
 			.then(res => {
-				expect(res).to.contain('&event_collection=page%3Aview')
+				expect(res).to.contain('event_collection=page%3Aview')
 			})
 	})
 
@@ -20,7 +20,7 @@ describe('generating URLS for keen-query: API', () => {
 
 		return kq.print('url')
 			.then(res => {
-				expect(res).to.contain('&timeframe=this_1_years')
+				expect(res).to.contain('timeframe=this_1_years')
 			})
 	})
 
@@ -30,7 +30,7 @@ describe('generating URLS for keen-query: API', () => {
 
 		return kq.print('url')
 			.then(res => {
-				expect(res).to.contain('&interval=monthly')
+				expect(res).to.contain('interval=monthly')
 			})
 	})
 
@@ -40,7 +40,7 @@ describe('generating URLS for keen-query: API', () => {
 
 		return kq.print('url')
 			.then(res => {
-				expect(res).to.contain('&filters=%5B%7B%22property_name%22%3A%22user.uuid%22%2C%22operator%22%3A%22exists%22%2C%22property_value%22%3Atrue%7D%5D')
+				expect(res).to.contain('filters=%5B%7B%22property_name%22%3A%22user.uuid%22%2C%22operator%22%3A%22exists%22%2C%22property_value%22%3Atrue%7D%5D')
 			})
 	})
 
@@ -50,9 +50,18 @@ describe('generating URLS for keen-query: API', () => {
 
 		return kq.print('url')
 			.then(res => {
-				expect(res).to.contain('&group_by=user.geo.continent')
+				expect(res).to.contain('group_by=user.geo.continent')
 			})
 	})
+
+	it('should have api-compatible urls for unique_count queries', () => {
+		const kq = KeenQuery.build('page:view->count(user.uuid)')
+		return kq.print('url')
+			.then(res => {
+				expect(res).to.contain('analysis_type=count_unique&target_property=user.uuid')
+			})
+	})
+
 })
 
 /* Keen explorer */
@@ -72,7 +81,7 @@ describe('generating URLS for keen-query: Explorer', () => {
 
 		return kq.print('explorer-url')
 			.then(res => {
-				expect(res).to.contain('&query[timeframe]=this_1_years')
+				expect(res).to.contain('query[timeframe]=this_1_years')
 			})
 	})
 
@@ -82,7 +91,7 @@ describe('generating URLS for keen-query: Explorer', () => {
 
 		return kq.print('explorer-url')
 			.then(res => {
-				expect(res).to.contain('&query[interval]=monthly')
+				expect(res).to.contain('query[interval]=monthly')
 			})
 	})
 
@@ -92,7 +101,7 @@ describe('generating URLS for keen-query: Explorer', () => {
 
 		return kq.print('explorer-url')
 			.then(res => {
-				expect(res).to.contain('&query[filters][0]=user.uuid&query[filters][0]=exists&query[filters][0]=true')
+				expect(res).to.contain('query[filters][0]=user.uuid&query[filters][0]=exists&query[filters][0]=true')
 			})
 	})
 
@@ -102,7 +111,15 @@ describe('generating URLS for keen-query: Explorer', () => {
 
 		return kq.print('explorer-url')
 			.then(res => {
-				expect(res).to.contain('&query[group_by]=user.geo.continent')
+				expect(res).to.contain('query[group_by]=user.geo.continent')
+			})
+	})
+
+	it('should have explorer-compatible urls for unique_count queries', () => {
+		const kq = KeenQuery.build('page:view->count(user.uuid)')
+		return kq.print('explorer-url')
+			.then(res => {
+				expect(res).to.contain('query[analysis_type]=count_unique&query[target_property]=user.uuid')
 			})
 	})
 })

--- a/test/keen-urls.test.js
+++ b/test/keen-urls.test.js
@@ -1,0 +1,108 @@
+'use strict'
+
+const KeenQuery = require('../lib/index.js')
+const expect = require('chai').expect
+
+/* Keen explorer */
+describe('generating URLS for keen-query: API', () => {
+
+	it('should have api-compatible urls for basic queries', () => {
+		const kq = KeenQuery.build('page:view->count()')
+		return kq.print('url')
+			.then(res => {
+				expect(res).to.contain('&event_collection=page%3Aview')
+			})
+	})
+
+// 	it('should have api-compatible urls for timeframed queries', () => {
+// 		const kq = KeenQuery.build('page:view->count()')
+// 			.relTime('this_1_years')
+
+// 		return kq.print('url')
+// 			.then(res => {
+// 				expect(res).to.contain('&timeframe=this_1_years')
+// 			})
+// 	})
+
+// 	it('should have api-compatible urls for intervalled queries', () => {
+// 		const kq = KeenQuery.build('page:view->count()')
+// 			.interval('month')
+
+// 		return kq.print('url')
+// 			.then(res => {
+// 				expect(res).to.contain('&interval=monthly')
+// 			})
+// 	})
+
+// 	it('should have api-compatible urls for filtered queries', () => {
+// 		const kq = KeenQuery.build('page:view->count()')
+// 			.filter('user.uuid')
+
+// 		return kq.print('url')
+// 			.then(res => {
+// 				expect(res).to.contain('&filters=%5B%7B%22property_name%22%3A%22user.uuid%22%2C%22operator%22%3A%22exists%22%2C%22property_value%22%3Atrue%7D%5D')
+// 			})
+// 	})
+
+// 	it('should have api-compatible urls for grouped queries', () => {
+// 		const kq = KeenQuery.build('page:view->count()')
+// 			.group('user.geo.continent')
+
+// 		return kq.print('url')
+// 			.then(res => {
+// 				expect(res).to.contain('&group_by=user.geo.continent')
+// 			})
+// 	})
+})
+
+/* Keen explorer */
+// describe('generating URLS for keen-query: Explorer', () => {
+
+// 	it('should have explorer-compatible urls for basic queries', () => {
+// 		const kq = KeenQuery.build('page:view->count()')
+// 		return kq.print('explorer-url')
+// 			.then(res => {
+// 				expect(res).to.contain('query[analysis_type]=count&query[event_collection]=page%3Aview')
+// 			})
+// 	})
+
+// 	it('should have explorer-compatible urls for timeframed queries', () => {
+// 		const kq = KeenQuery.build('page:view->count()')
+// 			.relTime('this_1_years')
+
+// 		return kq.print('explorer-url')
+// 			.then(res => {
+// 				expect(res).to.contain('&query[timeframe]=this_1_years')
+// 			})
+// 	})
+
+// 	it('should have explorer-compatible urls for intervalled queries', () => {
+// 		const kq = KeenQuery.build('page:view->count()')
+// 			.interval('month')
+
+// 		return kq.print('explorer-url')
+// 			.then(res => {
+// 				expect(res).to.contain('&query[interval]=monthly')
+// 			})
+// 	})
+
+// 	it('should have explorer-compatible urls for filtered queries', () => {
+// 		const kq = KeenQuery.build('page:view->count()')
+// 			.filter('user.uuid')
+
+// 		return kq.print('explorer-url')
+// 			.then(res => {
+// 				expect(res).to.contain('&query[filters][0]=user.uuid&query[filters][0]=exists&query[filters][0]=true')
+// 			})
+// 	})
+
+// 	it('should have explorer-compatible urls for grouped queries', () => {
+// 		const kq = KeenQuery.build('page:view->count()')
+// 			.group('user.geo.continent')
+
+// 		return kq.print('explorer-url')
+// 			.then(res => {
+// 				expect(res).to.contain('&query[group_by]=user.geo.continent')
+// 			})
+// 	})
+// })


### PR DESCRIPTION
cc @wheresrhys 

![image](https://cloud.githubusercontent.com/assets/224547/12824065/45885220-cb67-11e5-8cf8-c113e12b1976.png)

I'll need to update https://github.com/Financial-Times/next-beacon-v2/blob/master/client/components/render.js#L20 and https://github.com/Financial-Times/n-keen-query/blob/master/lib/n-keen-query.js#L30
