### PR TITLE
concat columns on to 2 dimensional table

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,10 +132,10 @@ Some methods expect a dimension to be specified e.g to choose between taking an 
 
 These combine multiple keen-queries using a predefined rule. They follow the syntax `@agregatorName(comma separated list of queries)`. So far they are not available In the JS API, and include:
 
-- `@ratio` - Given two queries returning results with identical structure, it returns a new table where the values are the result of dividing the value in the first table with its corresponding value in the second
+- `@ratio` - Given two queries returning results with similar structure, it returns a new table where the values are the result of dividing the value in the first table with its corresponding value in the second
 - `@pct` - as above but expressed as a percentage
 - `@sum` - Given two queries returning results with identical structure, it returns a new table where the values are the result of adding the value in the first table to its corresponding value in the second
-- `@concat` - **TODO (please request)** Given n queries returning results with similar structure, it combines them into a single table by concatenating the columns of each table
+- `@concat` - Given n queries returning results with similar structure, it combines them into a single table by concatenating the columns of each table
 - `@funnel` - **TODO**
 
 Aggregations must be created using `KeenQuery.build()`, which returns an object with the same interface as a `KeenQuery` instance, so reductions can be performed on it.
@@ -153,6 +153,8 @@ These allow values to be combined according to well known mathematical functions
 | Median value | `->reduce(median,timeframe)` | `kq.reduce('median','timeframe')` |
 | Trend (linear regression gradient) | `->reduce(trend,timeframe)` | `kq.reduce('trend','timeframe')` |
 | Percent change - % up/down in last 2 values | `->reduce(%change,timeframe)` | `kq.reduce('%change','timeframe')` |
+
+If a third paramter is set to `true` a table will be returned that concatenates the reduction on as an additional column
 
 #### Other
 

--- a/lib/aggregator/concat.js
+++ b/lib/aggregator/concat.js
@@ -43,28 +43,17 @@ function concat (tables) {
 		return table;
 	} else if (firstTable.dimension === 2 && otherTables.every(t => t.dimension === 1)) {
 		//concatenating a bunch of 1-dimension tables onto a 2-dimension table
-		throw new Error('Concatenating extra columsn onto a 2 dimensional table')
 		const table = firstTable.clone();
-		table.axes[1].values = table.axes[1].values.concat(otherTables.map(t => t.valueLabel));
+		const newHeadings = otherTables.map(t => t.valueLabel)
 
-		// table.data = table.axes[0].values.reduce((obj, name, i) => {
-		// 	tables.forEach((t, j) => {
-		// 		obj[`${i},${j}`] = t.data[i];
-		// 	})
-		// 	return obj;
-		// }, {});
+		newHeadings.forEach((name, i) => {
+			otherTables.forEach((t, j) => {
+				table.data[`${i},${table.axes[1].values.length + j}`] = t.data[i];
+			})
+		});
+		table.axes[1].values = table.axes[1].values.concat(newHeadings);
 
-
-		// const table = firstTable.clone();
-		// const existingColsCount = table.axes[0].values.length;
-		// table.axes[0].values = table.axes[0].values.concat(otherTables.map(t => t.valueLabel));
-		// otherTables.forEach((t, i) => {
-		// 	table.data[existingColsCount + i] = t.data;
-		// });
-
-
-
-		// return table;
+		return table;
 
 	} else {
 		throw new Error('Concatenating multi dimensional tables together is not supported (and probably isn\'t what you\re trying to do')

--- a/lib/aggregator/concat.js
+++ b/lib/aggregator/concat.js
@@ -63,3 +63,5 @@ function concat (tables) {
 module.exports = function () {
 	this._table = concat(this.queries.map(query => query.getTable()));
 };
+
+module.exports.concat = concat;

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -264,7 +264,7 @@ class Deconstructor {
 	}
 
 	deconstructQuery (str) {
-
+		str = str.trim();
 		if (str.charAt(0) === '@') {
 			return this.deconstructAggregator(str);
 		}

--- a/lib/post-processing/reduce.js
+++ b/lib/post-processing/reduce.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const concatUtil = require('../aggregator/concat').concat;
+
 function linearRegression(arr){
 	var n = arr.length;
 	var sum_x = 0;
@@ -53,7 +55,7 @@ const strategiesMap = {
 	}
 };
 
-module.exports.reduce = function (strategy, dimension) {
+module.exports.reduce = function (strategy, dimension, concat) {
 	dimension = typeof dimension === 'undefined' ? this.dimension - 1 : this.getAxis(dimension);
 	let table = this;
 	if (dimension !== this.dimension - 1) {
@@ -90,10 +92,15 @@ module.exports.reduce = function (strategy, dimension) {
 		axes.pop();
 	}
 
-	return table.clone({
+	const reducedTable = table.clone({
 		axes,
 		data: buckets
-	})
+	});
+
+	if (concat) {
+		return concatUtil([table.clone(), reducedTable]);
+	}
+	return reducedTable
 }
 
 module.exports.reduceStrategies = strategiesMap;


### PR DESCRIPTION
so e.g, you can run a query which groups by some property and then has an additional column to show the sum/avg of all the values. May make your dashboards more streamlined (both in terms of speed and number of graphs required)
@andygout @laurieboyes 

@adambraimbridge - by using the js API from within beacon this could be used to add total, avg etc. as a big number to a graph. Could add something to the dashboards yaml 'withSummaries: true` to enable this per graph