### PR TITLE
Performance optimisation of tabuation for large datasets

### DIFF
--- a/bin/keen-query.js
+++ b/bin/keen-query.js
@@ -1,4 +1,3 @@
 #!/usr/bin/env node
 'use strict';
-
 require('../lib/cli').init();

--- a/lib/keen-query/index.js
+++ b/lib/keen-query/index.js
@@ -15,6 +15,7 @@ if (!configContainer || !configContainer.KEEN_PROJECT_ID || !configContainer.KEE
 
 const forcedQueries = [];
 
+
 class KeenQuery {
 	constructor (event) {
 		this.dimensions = [];
@@ -400,6 +401,7 @@ class KeenQuery {
 			.then(res => res.json())
 			.then(data => {
 				this._data = data;
+
 				this._table = this._tabulate(data);
 				if (this._postProcessing) {
 					this._postProcessing.forEach(opts => {

--- a/lib/post-processing/cutoff.js
+++ b/lib/post-processing/cutoff.js
@@ -27,13 +27,13 @@ module.exports.top = function (n, percentOrRaw, strategy, dimension) {
 		n = n * table.size[axis] / 100
 	}
 	const map = {};
+
 	table.cellIterator((value, coords) => {
 		if (Number(coords.split(',')[axis]) < n) {
 			map[coords] = value;
 		}
 	})
 	table.data = map;
-	// console.log(map)
 	table.axes[axis].values = table.axes[axis].values.slice(0, n);
 	return table;
 }

--- a/lib/tabulate.js
+++ b/lib/tabulate.js
@@ -2,6 +2,7 @@
 const Table = require('./table');
 
 function tabulate () {
+
 	if (!this.dimension) {
 		return new Table({
 			axes: [],
@@ -27,23 +28,50 @@ function tabulate () {
 		}
 	});
 
+	// Using ES5 as this bit of code is a real bottleneck, so want full control over the babelified output
+	/* eslint-disable */
+	var indexMemo = {};
+	axes.forEach(a => {
+		if (a.property !== 'timeframe') {
+			a.values.forEach(function (v, i) {
+				indexMemo[a.property + '::' + v] = i;
+			})
+		}
+	})
+
+	var data = {};
+	var points = this._data.result;
+	var i = points.length;
+	var res;
+	var coords;
+	var val;
+
+	while (i--) {
+		res = points[i];
+
+		coords = axes.map(function (axis) {
+
+			val = res[axis.property];
+			if (val === null || val === false || val === true) {
+				val = '' + val;
+			}
+
+			if (axis.property === 'timeframe') {
+				return axis.values.indexOf(val);
+			}
+
+			return indexMemo[axis.property + '::' + val];
+		});
+
+		data[coords.join(',')] = res.result;
+	}
+	/* eslint-enable */
 
 	return new Table({
 		axes: axes,
 		interval: this.intervalUnit,
 		valueLabel: this.valueLabel,
-		data: this._data.result.reduce((map, res) => {
-			const coords = axes.map(axis => {
-				let val = res[axis.property];
-				if (val === null || val === false || val === true) {
-					val = '' + val;
-				}
-				return axis.values.indexOf(val);
-			});
-
-			map[coords.join(',')] = res.result;
-			return map;
-		}, {})
+		data: data
 	});
 
 }


### PR DESCRIPTION
This cuts time to tabulate the pages viewed table for anonymous users from 10s to 0.1s, so the anonymous page on beacon will no longer freeze @adambraimbridge 