### PR TITLE
V3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ install:
 	npm install
 
 test-unit:
-	export KEEN_PROJECT_ID=test_proj; export KEEN_READ_KEY=test_key; mocha test
+	mocha test/helpers.js test
 
 test: test-unit
 	nbt verify --skip-layout-checks

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ There are a few built in methods for outputting data
 | JSON representation of the query | `->print(qo)` | `kq.print('qo') |
 | Stringified JSON representation of the query | `->print(qs)` | `kq.print('qs') |
 | The raw JSON response(s) from Keen | `->print(raw)` | `kq.print('raw') |
-| Normalised JSON of the response (a 2 dimensional matrix with headings) | `->print(json)` | `kq.print('json') |
+| Flattened matrix representation of the response | `->print(matrix)` | `kq.print('matrix') |
 | Prints out an ASCII table of the results | `->print(ascii)` | `kq.print('ascii') |
 
 `KeenQuery.definePrinter(name, func)` can be used to define your own printers (e.g. to output a graph to the DOM). Within `func`, `this` will point at the current KeenQuery instance, and `this.getTable()` will give access to an object with the following properties and methods:
@@ -226,5 +226,4 @@ the Keen data with all aggregations, reductions etc. already applied.
 ### Utilities
 
 - KeenQuery.parseFilter(str) - converts a string compatible with the above syntax into a Keen filter object
-- KeenQuery.forceQuery(func) - the function will be run as part of every query. Useful for e.g. excluding test data from results
 - KeenQuery.defineQuery(name, func) - defines a method `name` which can be used as part of a keen-query string or in the JS API.

--- a/README.md
+++ b/README.md
@@ -148,13 +148,13 @@ These allow values to be combined according to well known mathematical functions
 
 | Function | String | JS API |
 | ------------- |-------------| -----|
-| Average of values | `->reduce(avg,timeframe)` | `kq.reduce('avg','timeframe')` |
-| Sum of values | `->reduce(sum,timeframe)` | `kq.reduce('sum','timeframe')` |
-| Minimum value | `->reduce(min,timeframe)` | `kq.reduce('min','timeframe')` |
-| Maximum value | `->reduce(max,timeframe)` | `kq.reduce('max','timeframe')` |
-| Median value | `->reduce(median,timeframe)` | `kq.reduce('median','timeframe')` |
-| Trend (linear regression gradient) | `->reduce(trend,timeframe)` | `kq.reduce('trend','timeframe')` |
-| Percent change - % up/down in last 2 values | `->reduce(%change,timeframe)` | `kq.reduce('%change','timeframe')` |
+| Average of values | `->reduce(timeframe,avg)` | `kq.reduce('timeframe', 'avg')` |
+| Sum of values | `->reduce(timeframe,sum)` | `kq.reduce('timeframe', 'sum')` |
+| Minimum value | `->reduce(timeframe,min)` | `kq.reduce('timeframe', 'min')` |
+| Maximum value | `->reduce(timeframe,max)` | `kq.reduce('timeframe', 'max')` |
+| Median value | `->reduce(timeframe,median)` | `kq.reduce('timeframe', 'median')` |
+| Trend (linear regression gradient) | `->reduce(timeframe,trend)` | `kq.reduce('timeframe', 'trend')` |
+| Percent change - % up/down in last 2 values | `->reduce(timeframe,%change)` | `kq.reduce('timeframe', '%change')` |
 
 If a third paramter is set to `true` a table will be returned that concatenates the reduction on as an additional column
 

--- a/README.md
+++ b/README.md
@@ -166,9 +166,9 @@ If a third paramter is set to `true` a table will be returned that concatenates 
 - `divide(n)` Divides each value by n
 - `sortAsc()` (1 dimensional tables only)
 - `sortDesc()` (1 dimensional tables only)
-- `sortProp(property,value1,value2,...)` Sorts rows in the result according to values in the `property` axis, in the order given
+- `reorder(property,value1,value2,...)` Sorts rows in the result according to values in the `property` axis, in the order given
 - `plotThreshold(value, name)` For graphs over time, draws an additional line fixed at the given value
-- `relabel(property,value1,value2,...)` relabels the data labels in the `property` axis (unwise to use this unless e.g using @concat on a preditable set of values, or if using `->sortProp()` first)
+- `relabel(property,value1,value2,...)` relabels the data labels in the `property` axis (unwise to use this unless e.g using @concat on a preditable set of values, or if using `->reorder()` first)
 
 #### Experimental
 

--- a/README.md
+++ b/README.md
@@ -172,8 +172,8 @@ If a third paramter is set to `true` a table will be returned that concatenates 
 
 #### Experimental
 
-- `top(n,[percent])`/ `bottom(n,[percent])` shows the top/bottom n (or n percent) of results
-- `cutoff(n,[percent])` ignore all values smaller than n (or n percent of the total)
+- `top(n)`/ `bottom(n)` shows the top/bottom n (or n percent if the last character is '%') of results
+- `cutoff(n)` ignore all values smaller than n (or n percent if the last character is '%')
 - `sortAsc(prop,[reduction,dimension])`
 - `sortDesc(prop,[reduction,dimension])`
 

--- a/lib/aggregator/concat.js
+++ b/lib/aggregator/concat.js
@@ -19,7 +19,7 @@ function concat (matrices) {
 		// We just bundle all the values and valueLabels up into a single row matrix
 		return new ImmutableMatrix({
 			axes: [{
-				property: 'CONCATENATION_RESULT',
+				property: '_headings',
 				values: matrices.map(t => t.valueLabel)
 			}],
 			// even though data should technically be an object we can get away with using an array
@@ -51,7 +51,7 @@ function concat (matrices) {
 
 		// We build a second axis for the matrix out of the valueLabels of each matrix
 		matrix.axes[1] = {
-			property: 'CONCATENATION_RESULT',
+			property: '_headings',
 			values: matrices.map(t => t.valueLabel)
 		};
 		// We build a flat representation of a 2 dimensional array by iterating through the

--- a/lib/aggregator/concat.js
+++ b/lib/aggregator/concat.js
@@ -6,97 +6,97 @@
 	trying to understand the next. Each one handles a slightly more complex case than
 	the previous and can be thought of as a hybrid of the two preceding approaches
 **/
-function concat (tables) {
+function concat (matrices) {
 	// circular dependency hell!
-	const Table = require('../table');
+	const ImmutableMatrix = require('../data/immutable-matrix');
 	// end circular dependency hell!
-	const firstTable = tables[0];
-	const otherTables = tables.slice(1);
+	const firstMatrix = matrices[0];
+	const otherMatrices = matrices.slice(1);
 
-	// Concatenating a bunch of 0-dimension tables together
-	if (firstTable.dimension === 0 && otherTables.every(t => t.dimension === 0)) {
+	// Concatenating a bunch of 0-dimension matrices together
+	if (firstMatrix.dimension === 0 && otherMatrices.every(t => t.dimension === 0)) {
 
-		// We just bundle all the values and valueLabels up into a single row table
-		return new Table({
+		// We just bundle all the values and valueLabels up into a single row matrix
+		return new ImmutableMatrix({
 			axes: [{
 				property: 'CONCATENATION_RESULT',
-				values: tables.map(t => t.valueLabel)
+				values: matrices.map(t => t.valueLabel)
 			}],
 			// even though data should technically be an object we can get away with using an array
-			// as the flat object for a 1 dimensional table would only have keys '0', '1', '2' ... anyway
-			data: tables.map(t => t.data)
+			// as the flat object for a 1 dimensional matrix would only have keys '0', '1', '2' ... anyway
+			data: matrices.map(t => t.data)
 		});
 
-	// Concatenating a bunch of 0-dimension tables onto a 1-dimension table
-	} else if (firstTable.dimension === 1 && otherTables.every(t => t.dimension === 0)) {
+	// Concatenating a bunch of 0-dimension matrices onto a 1-dimension matrix
+	} else if (firstMatrix.dimension === 1 && otherMatrices.every(t => t.dimension === 0)) {
 
 		// As the data structure we start with isn't shallow and easy to copy, we begin by cloning
-		const table = firstTable.clone();
+		const matrix = firstMatrix.clone();
 		// Anything we append we will need to offset by the number of values that already exist, so we make a note
-		const existingColsCount = table.axes[0].values.length;
-		// We append the valueLabel for each of the sibling tables to the end of our new table's list of labels
-		table.axes[0].values = table.axes[0].values.concat(otherTables.map(t => t.valueLabel));
-		// Now we take the single value from each sibling table and append to the new table's data
-		otherTables.forEach((t, i) => {
-			table.data[existingColsCount + i] = t.data;
+		const existingColsCount = matrix.axes[0].values.length;
+		// We append the valueLabel for each of the sibling matrices to the end of our new matrix's list of labels
+		matrix.axes[0].values = matrix.axes[0].values.concat(otherMatrices.map(t => t.valueLabel));
+		// Now we take the single value from each sibling matrix and append to the new matrix's data
+		otherMatrices.forEach((t, i) => {
+			matrix.data[existingColsCount + i] = t.data;
 		});
-		return table;
+		return matrix;
 
-	// Concatenating a bunch of 1-dimension tables together into a 2 dimensional table
-	} else if (firstTable.dimension === 1 && otherTables.every(t => t.dimension === 1)) {
-		// TODO check axes and throw Error if tables do not have identical axes
+	// Concatenating a bunch of 1-dimension matrices together into a 2 dimensional matrix
+	} else if (firstMatrix.dimension === 1 && otherMatrices.every(t => t.dimension === 1)) {
+		// TODO check axes and throw Error if matrices do not have identical axes
 
 		// As above, we begin by making a deep clone
-		const table = firstTable.clone();
+		const matrix = firstMatrix.clone();
 
-		// We build a second axis for the table out of the valueLabels of each table
-		table.axes[1] = {
+		// We build a second axis for the matrix out of the valueLabels of each matrix
+		matrix.axes[1] = {
 			property: 'CONCATENATION_RESULT',
-			values: tables.map(t => t.valueLabel)
+			values: matrices.map(t => t.valueLabel)
 		};
 		// We build a flat representation of a 2 dimensional array by iterating through the
-		// values of the first axis and each of the tables, storing their values in "0,0", "0,1" etc...
-		table.data = table.axes[0].values.reduce((obj, name, i) => {
-			tables.forEach((t, j) => {
-				obj[`${i},${j}`] = t.data[firstTable.findEquivalentCoords(i, t.axes)];
+		// values of the first axis and each of the matrices, storing their values in "0,0", "0,1" etc...
+		matrix.data = matrix.axes[0].values.reduce((obj, name, i) => {
+			matrices.forEach((t, j) => {
+				obj[`${i},${j}`] = t.data[firstMatrix.findEquivalentCoords(i, t.axes)];
 			})
 			return obj;
 		}, {});
 
-		return table;
+		return matrix;
 
-	// Concatenating a bunch of 1-dimension tables onto a 2-dimension table
-	} else if (firstTable.dimension === 2 && otherTables.every(t => t.dimension === 1)) {
+	// Concatenating a bunch of 1-dimension matrices onto a 2-dimension matrix
+	} else if (firstMatrix.dimension === 2 && otherMatrices.every(t => t.dimension === 1)) {
 
 		// We - yawn - clone again
-		const table = firstTable.clone();
+		const matrix = firstMatrix.clone();
 
 		// Similar to the second case, way way above, we have to offset by the number of existing values
-		// as we are appending to an existing table
-		const valueOffset = table.axes[1].values.length;
+		// as we are appending to an existing matrix
+		const valueOffset = matrix.axes[1].values.length;
 
-		// We get headings for each new column of the table from the valueLabels of the sibling tables
-		table.axes[1].values = table.axes[1].values.concat(otherTables.map(t => t.valueLabel));
+		// We get headings for each new column of the matrix from the valueLabels of the sibling matrices
+		matrix.axes[1].values = matrix.axes[1].values.concat(otherMatrices.map(t => t.valueLabel));
 
-		// Similar to the above, we iterate through the sibling tables and the values of the
+		// Similar to the above, we iterate through the sibling matrices and the values of the
 		// first axis (I can't recall if there's a reason the iteration is nested in the reverse order
 		// to that above)
-		otherTables.forEach((name, i) => {
-			table.axes[0].values.forEach((v, j) => {
-				table.data[`${j},${valueOffset + i}`] = otherTables[i].data[j];
+		otherMatrices.forEach((name, i) => {
+			matrix.axes[0].values.forEach((v, j) => {
+				matrix.data[`${j},${valueOffset + i}`] = otherMatrices[i].data[j];
 			})
 		});
 
-		return table;
+		return matrix;
 
 	} else {
-		throw new Error(`Concatenating multi dimensional tables together is not supported
+		throw new Error(`Concatenating multi dimensional matrices together is not supported
 (and probably isn\'t what you want anyway - think how confusing the graph would be!!!)`)
 	}
 }
 
 module.exports = function () {
-	this._table = concat(this.queries.map(query => query.getTable()));
+	this._matrix = concat(this.queries.map(query => query.getData()));
 };
 
 module.exports.getDimension = function () {

--- a/lib/aggregator/funnel.js
+++ b/lib/aggregator/funnel.js
@@ -3,7 +3,6 @@
 const printers = require('../printers');
 const KeenQuery = require('../keen-query');
 const ImmutableMatrix = require('../data/immutable-matrix');
-const config = process.browser ? window : process.env;
 
 class Funnel {
 	constructor (conf) {

--- a/lib/aggregator/funnel.js
+++ b/lib/aggregator/funnel.js
@@ -1,8 +1,9 @@
 'use strict';
 
 const printers = require('../printers');
+const KeenQuery = require('../keen-query');
 const ImmutableMatrix = require('../data/immutable-matrix');
-const configContainer = process.browser ? window : process.env;
+const config = process.browser ? window : process.env;
 
 class Funnel {
 	constructor (conf) {
@@ -23,7 +24,7 @@ class Funnel {
 	}
 
 	print (style) {
-
+		const config = KeenQuery.getConfig();
 		style = style || this._printer;
 
 		if (style === 'qs' || style === 'qo') {
@@ -36,7 +37,7 @@ class Funnel {
 
 		return Promise.all(this.queries.map(q => q.print('funnelStep')))
 			.then(queries => {
-				const url = `https://api.keen.io/3.0/projects/${configContainer.KEEN_PROJECT_ID}/queries/funnel?api_key=${configContainer.KEEN_READ_KEY}&steps=${encodeURIComponent(JSON.stringify(queries))}`;
+				const url = `https://api.keen.io/3.0/projects/${config.KEEN_PROJECT_ID}/queries/funnel?api_key=${config.KEEN_READ_KEY}&steps=${encodeURIComponent(JSON.stringify(queries))}`;
 				if (style === 'url') {
 					return url;
 				}

--- a/lib/aggregator/funnel.js
+++ b/lib/aggregator/funnel.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const printers = require('../printers');
-const Table = require('../table');
+const ImmutableMatrix = require('../data/immutable-matrix');
 const configContainer = process.browser ? window : process.env;
 
 class Funnel {
@@ -30,7 +30,7 @@ class Funnel {
 			return Promise.all(this.queries.map(q => q.print(style)));
 		}
 
-		if (this._table) {
+		if (this._matrix) {
 			return Promise.resolve(printers.call(this, style))
 		}
 
@@ -43,19 +43,19 @@ class Funnel {
 				return fetch(url)
 					.then(res => res.json())
 					.then(data => {
-						this._data = data;
-						this._table = new Table({
+						this._rawData = data;
+						this._matrix = new ImmutableMatrix({
 							axes: [{
 								property: 'step',
 								values: this.queries.map(q => q.valueLabel)
 							}],
-							data: this._data.result
+							data: this._rawData.result
 						});
 					})
 					.then(() => {
 						if (this._postProcessors) {
 							this._postProcessors.forEach(opts => {
-								this._table = this.getTable()[opts.func].apply(this.getTable(), opts.params);
+								this._matrix = this.getData()[opts.func].apply(this.getData(), opts.params);
 							})
 						}
 						return printers.call(this, style)
@@ -81,7 +81,7 @@ class Funnel {
 		// allow for an aggregator to calculate its dimension explictly, otherwise
 		// default to assuming all the queries are being combined without altering
 		// their dimension
-		return this._dimension || (this._table && this._table.dimension) || this.queries[0].dimension;
+		return this._dimension || (this._matrix && this._matrix.dimension) || this.queries[0].dimension;
 	}
 
 	generateKeenUrl(base, format) {
@@ -98,19 +98,19 @@ class Funnel {
 		aggregator._printer = this._printer;
 		aggregator._postProcessors = this._postProcessors && this._postProcessors.slice().map(f => Object.assign({}, f));
 		if (withData) {
-			aggregator._table = this.getTable() && this.getTable().clone();
+			aggregator._matrix = this.getData() && this.getData().clone();
 		}
 		return aggregator;
 	}
 
-	getTable () {
-		return this._table;
+	getData () {
+		return this._matrix;
 	}
 }
 
-// Mixin a load of table methods so they can be applied to the data via the aggregator
+// Mixin a load of matrix methods so they can be applied to the data via the aggregator
 // that wraps it
-Table.mixin(Funnel.prototype);
+ImmutableMatrix.mixin(Funnel.prototype);
 
 // Mixin a load of keen-query methods so that child queries can be modified post-hoc
 ['raw', 'interval', 'absTime', 'relTime', 'group', 'filter', 'tidy'].forEach(method => {

--- a/lib/aggregator/index.js
+++ b/lib/aggregator/index.js
@@ -127,6 +127,10 @@ class Aggregator {
 		return this._matrix;
 	}
 
+	getTable (dateStyle) {
+		return this._matrix.unflatten(dateStyle);
+	}
+
 	static factory (conf) {
 		if (conf.aggregator === 'funnel') {
 			return new Funnel(conf);

--- a/lib/aggregator/index.js
+++ b/lib/aggregator/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const printers = require('../printers');
-const Table = require('../table');
+const ImmutableMatrix = require('../data/immutable-matrix');
 const Funnel = require('./funnel');
 const postProcessing = require('../post-processing');
 
@@ -57,15 +57,15 @@ class Aggregator {
 			return Promise.all(this.queries.map(q => q.print(style)));
 		}
 
-		if (this._table) {
+		if (this._matrix) {
 			return Promise.resolve(printers.call(this, style))
 		}
 
-		return Promise.all(this.queries.map(q => q.print('json')))
+		return Promise.all(this.queries.map(q => q.print('matrix')))
 			.then(() => this.aggregator())
 			.then(() => {
 				postProcessors.forEach(opts => {
-					this._table = this.getTable()[opts.func].apply(this.getTable(), opts.params);
+					this._matrix = this.getData()[opts.func].apply(this.getData(), opts.params);
 				})
 				return printers.call(this, style)
 			})
@@ -101,7 +101,7 @@ class Aggregator {
 		// allow for an aggregator to calculate its dimension explictly, otherwise
 		// default to assuming all the queries are being combined without altering
 		// their dimension
-		return this._dimension || (this._table && this._table.dimension) || this.queries[0].dimension;
+		return this._dimension || (this._matrix && this._matrix.dimension) || this.queries[0].dimension;
 	}
 
 	generateKeenUrl(base, format) {
@@ -118,13 +118,13 @@ class Aggregator {
 		aggregator._printer = this._printer;
 		aggregator.sharedFunctions = this.sharedFunctions && this.sharedFunctions.slice().map(f => Object.assign({}, f));
 		if (withData) {
-			aggregator._table = this.getTable() && this.getTable().clone();
+			aggregator._matrix = this.getData() && this.getData().clone();
 		}
 		return aggregator;
 	}
 
-	getTable () {
-		return this._table;
+	getData () {
+		return this._matrix;
 	}
 
 	static factory (conf) {
@@ -156,7 +156,7 @@ class Aggregator {
 
 // Mixin a load of table methods so they can be applied to the data via the aggregator
 // that wraps it
-Table.mixin(Aggregator.prototype);
+ImmutableMatrix.mixin(Aggregator.prototype);
 
 // Mixin a load of keen-query methods so that child queries can be modified post-hoc
 ['raw', 'interval', 'absTime', 'relTime', 'group', 'filter', 'tidy'].forEach(method => {

--- a/lib/aggregator/pct.js
+++ b/lib/aggregator/pct.js
@@ -4,6 +4,6 @@ const ratio = require('./ratio');
 
 // Basically just a wrapper for @ratio which mutiplies by 100 and rounds
 module.exports = function () {
-	this._table = ratio.calculateRatio(this.queries[0].getTable(), this.queries[1].getTable()).multiply(100).round(1);
-	this._table.valueLabel = `${this.queries[0].getTable().valueLabel} / ${this.queries[1].getTable().valueLabel} %`;
+	this._matrix = ratio.calculateRatio(this.queries[0].getData(), this.queries[1].getData()).multiply(100).round(1);
+	this._matrix.valueLabel = `${this.queries[0].getData().valueLabel} / ${this.queries[1].getData().valueLabel} %`;
 }

--- a/lib/aggregator/ratio.js
+++ b/lib/aggregator/ratio.js
@@ -1,23 +1,23 @@
 'use strict';
 
-const Table = require('../table');
+const ImmutableMatrix = require('../data/immutable-matrix');
 const isGappy = require('../utils').isGappy;
 
-function calculateRatio (table1, table2) {
+function calculateRatio (matrix1, matrix2) {
 
 	let data;
 
-	if (table1.dimension === 0 && table2.dimension === 0) {
+	if (matrix1.dimension === 0 && matrix2.dimension === 0) {
 		// For the simplest case we just divide two values
-		data = table1.data / table2.data;
+		data = matrix1.data / matrix2.data;
 
 	// Both tables are of the same dimension, so there should be more or less a one-to-one
 	// mapping between their values. We just need to find the corresponding cells and divide them
-	} else if (table1.dimension === table2.dimension) {
+	} else if (matrix1.dimension === matrix2.dimension) {
 
 		// First we check to see if the tables' dimensions are the same
-		if (table2.axes.some((a, i) => {
-			return table1.axes[i].name !== a.name;
+		if (matrix2.axes.some((a, i) => {
+			return matrix1.axes[i].name !== a.name;
 		})) {
 			throw new Error('Tables are incompatible - grouped by different criteria');
 		}
@@ -25,37 +25,37 @@ function calculateRatio (table1, table2) {
 		// Then we check to see if there are any gaps in either table's data
 		// (Could happen if e.g. one table is last week's data, the other is this week's,
 		// and we introduced a new thing this week)
-		const tablesHaveGaps = isGappy(table1, table2);
+		const gapsExist = isGappy(matrix1, matrix2);
 
 		// We go through each cell of table 1
-		data = table1.cellIterator((value, coords) => {
+		data = matrix1.cellIterator((value, coords) => {
 			// if we know there are gaps we can't rely on the coordinates always being correct
 			// so we have to be careful to find th eexasct right cell
 			// TODO: consider doing this always as e.g. ordering could also screw us over
-			if (tablesHaveGaps) {
-				coords = table1.findEquivalentCoords(coords, table2.axes);
+			if (gapsExist) {
+				coords = matrix1.findEquivalentCoords(coords, matrix2.axes);
 			}
 			// finally divide the value by the equivalent one in the second table
-			return value / table2.data[coords];
+			return value / matrix2.data[coords];
 		});
 
 	// The first table is of greater dimension than the second
-	} else if (table1.dimension > table2.dimension) {
+	} else if (matrix1.dimension > matrix2.dimension) {
 
 
-		if (table2.dimension === 0) {
+		if (matrix2.dimension === 0) {
 			// If the second table holds a single value only then we just need to divide each value
 			// in the first table by it - easy peasy, lemon squeasy :)
-			data = table1.cellIterator(value => {
-				return value / table2.data;
+			data = matrix1.cellIterator(value => {
+				return value / matrix2.data;
 			});
 		} else {
 			// Otherwise we need to find equivalent coordinates in the table of lower dimension
-			// (Difficult difficult, lemon difficult. See the findEquivalentCoords method in the Table
+			// (Difficult difficult, lemon difficult. See the findEquivalentCoords method in the ImmutableMatrix
 			// class for the magic that makes it work)
-			data = table1.cellIterator((value, coords) => {
-				coords = table1.findEquivalentCoords(coords, table2.axes);
-				return value / table2.data[coords];
+			data = matrix1.cellIterator((value, coords) => {
+				coords = matrix1.findEquivalentCoords(coords, matrix2.axes);
+				return value / matrix2.data[coords];
 			});
 		}
 	} else {
@@ -63,14 +63,14 @@ function calculateRatio (table1, table2) {
 	}
 
 	// Now we've built the data we just return a new table, with the value label adjusted accordingly
-	return new Table(Object.assign({}, table1, {
+	return new ImmutableMatrix(Object.assign({}, matrix1, {
 		data: data,
-		valueLabel: `${table1.valueLabel} / ${table2.valueLabel}`
+		valueLabel: `${matrix1.valueLabel} / ${matrix2.valueLabel}`
 	}));
 }
 
 module.exports = function () {
-	this._table = calculateRatio(this.queries[0].getTable(), this.queries[1].getTable())
+	this._matrix = calculateRatio(this.queries[0].getData(), this.queries[1].getData())
 }
 
 module.exports.calculateRatio = calculateRatio;

--- a/lib/aggregator/sum.js
+++ b/lib/aggregator/sum.js
@@ -1,21 +1,21 @@
 'use strict';
 
-const Table = require('../table');
-function calculateSum (table1, table2) {
-	if (table1.dimension !== table2.dimension) {
+const ImmutableMatrix = require('../data/immutable-matrix');
+function calculateSum (matrix1, matrix2) {
+	if (matrix1.dimension !== matrix2.dimension) {
 		throw new Error('Tables are incompatible - wrong dimension');
 	}
 
-	if (table1.size.join(',') !== table2.size.join(',')) {
+	if (matrix1.size.join(',') !== matrix2.size.join(',')) {
 		throw new Error('Tables are incompatible - different number of rows/columns');
 	}
 	// TODO need to use that .findEquivalentCoords method more widely
-	const data = table1.dimension ? table1.cellIterator((value, coords) => value + table2.data[coords]) : table1.data + table2.data;
-	return new Table(Object.assign({}, table1, {
+	const data = matrix1.dimension ? matrix1.cellIterator((value, coords) => value + matrix2.data[coords]) : matrix1.data + matrix2.data;
+	return new ImmutableMatrix(Object.assign({}, matrix1, {
 		data: data
 	}));
 }
 
 module.exports = function () {
-	this._table = calculateSum(this.queries[0].getTable(), this.queries[1].getTable())
+	this._matrix = calculateSum(this.queries[0].getData(), this.queries[1].getData())
 }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -4,6 +4,16 @@ const program = require('commander');
 const KeenQuery = require('./keen-query');
 const base = require('./index');
 
+if (!process.env.KEEN_PROJECT_ID || !process.env.KEEN_READ_KEY) {
+	console.log('Make sure you have KEEN_READ_KEY and KEEN_PROJECT_ID env vars set.');
+	process.exit(1);
+}
+
+KeenQuery.setConfig({
+	KEEN_PROJECT_ID: process.env.KEEN_PROJECT_ID,
+	KEEN_READ_KEY: process.env.KEEN_READ_KEY
+});
+
 function executeQuery (query, pipe) {
 	let print = 'ascii';
 	let dots;

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -12,7 +12,7 @@ function executeQuery (query, pipe) {
 		print = 'tsv';
 	} else {
 		if (/->print\(/.test(query)) {
-			print = 'json';
+			print = 'matrix';
 		}
 		dots = setInterval(() => process.stdout.write('.'), 100)
 	}
@@ -27,7 +27,7 @@ function executeQuery (query, pipe) {
 	keenQuery
 		.print(print)
 		.then(str => {
-			if (print === 'json') {
+			if (print === 'matrix') {
 				console.log('\n', JSON.stringify(str, null, '\t'));
 			} else if (print === 'tsv') {
 				console.log(str);

--- a/lib/data/immutable-matrix.js
+++ b/lib/data/immutable-matrix.js
@@ -117,7 +117,7 @@ class ImmutableMatrix {
 			output.rows = [[table.valueLabel, table.data]]
 			return output;
 		} else if (table.dimension === 1) {
-			// if (table.axes[0].property === 'CONCATENATION_RESULT') {
+			// if (table.axes[0].property === '_headings') {
 			// 	output.headings = table.axes[0].values;
 			// } else {
 				output.headings = [table.axes[0].property, table.valueLabel]

--- a/lib/data/immutable-matrix.js
+++ b/lib/data/immutable-matrix.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const utils = require('./utils');
-const postProcessing = require('./post-processing');
+const utils = require('../utils');
+const postProcessing = require('../post-processing');
 
 // utility used to plot a value in a nested array
 function plotInMatrix (matrix, coords, val, endDepth) {
@@ -45,7 +45,7 @@ function nestLowerLevels (flatData, endLevel) {
 	return obj
 }
 
-class Table {
+class ImmutableMatrix {
 	constructor (conf) {
 		this.name = conf.name;
 		this.data = conf.data;
@@ -106,41 +106,41 @@ class Table {
 
 	// converts a table to a the sort of data structure graphing libraries typically require
 	// i.e. a header row, then a number of rows with a heading in the first cell of each
-	humanize (timeFormat) {
+	unflatten (timeFormat) {
 		if (this.dimension > 2) {
-			throw new Error('can\'t humanize tables of greater than 2 dimensions');
+			throw new Error('can\'t unflatten tables of greater than 2 dimensions');
 		}
 		const table = this.convertTime(timeFormat);
-		const humanized = {};
+		const output = {};
 		if (this.dimension === 0) {
 			// just send back a single cell
-			humanized.rows = [[table.valueLabel, table.data]]
-			return humanized;
+			output.rows = [[table.valueLabel, table.data]]
+			return output;
 		} else if (table.dimension === 1) {
 			// if (table.axes[0].property === 'CONCATENATION_RESULT') {
-			// 	humanized.headings = table.axes[0].values;
+			// 	output.headings = table.axes[0].values;
 			// } else {
-				humanized.headings = [table.axes[0].property, table.valueLabel]
+				output.headings = [table.axes[0].property, table.valueLabel]
 			// }
-			humanized.rows = table.axes[0].values.map((label, i) => {
+			output.rows = table.axes[0].values.map((label, i) => {
 				return [label, table.data[i]]; // this works because [i] notation works on an object or an array :-)
 			})
 		} else {
 			const data = table.toNested();
 
-			humanized.headings = [table.axes[0].property].concat(table.axes[1].values);
-			humanized.rows = table.axes[0].values.map((label, i) => {
+			output.headings = [table.axes[0].property].concat(table.axes[1].values);
+			output.rows = table.axes[0].values.map((label, i) => {
 				return [label].concat(data[i]);
 			})
 		}
-		const cols = humanized.headings.length;
-		humanized.rows.forEach(r => {
+		const cols = output.headings.length;
+		output.rows.forEach(r => {
 			for(let i = 0; i<cols;i++) {
 				// transform empty values to 0 or empty strings for consumption by google charts
 				r[i] = r[i] || (i > 0 ? 0 : '');
 			}
 		})
-		return humanized;
+		return output;
 	}
 
 	// returns a nested 'matrix' of the data
@@ -244,7 +244,7 @@ class Table {
 	}
 
 	clone (overrides) {
-		return new Table(Object.assign({}, this, overrides || {}));
+		return new ImmutableMatrix(Object.assign({}, this, overrides || {}));
 	}
 
 	// swaps two dimensions of the table
@@ -319,11 +319,11 @@ class Table {
 	}
 }
 
-module.exports = Table;
+module.exports = ImmutableMatrix;
 
 // Post processing methods can be quite convoluted, so are defined elsewhere
 // and mixed back in to the prototype here
-postProcessing.mixin(Table.prototype);
+postProcessing.mixin(ImmutableMatrix.prototype);
 
 // So they can be called on aggregators and keen-query objects all post processing methods
 // can also, via this mixin, made available on any object that wraps a table
@@ -337,8 +337,8 @@ module.exports.mixin = function (wrapperPrototype) {
 				params: [].slice.call(arguments)
 			});
 
-			if (target._table) {
-				target._table = method.apply(target.getTable(), [].slice.call(arguments))
+			if (target._matrix) {
+				target._matrix = method.apply(target.getData(), [].slice.call(arguments))
 			}
 
 			return target;

--- a/lib/data/immutify-keen.js
+++ b/lib/data/immutify-keen.js
@@ -1,12 +1,12 @@
 'use strict';
-const Table = require('./table');
+const ImmutableMatrix = require('./immutable-matrix');
 
-function tabulate () {
+function immutifyKeen () {
 
 	if (!this.dimension) {
-		return new Table({
+		return new ImmutableMatrix({
 			axes: [],
-			data: this._data.result,
+			data: this._rawData.result,
 			valueLabel: this.valueLabel
 		});
 	}
@@ -15,13 +15,13 @@ function tabulate () {
 		if (dimension === 'timeframe') {
 			return {
 				property: 'timeframe',
-				values: this._data.timeframes,
+				values: this._rawData.timeframes,
 				type: 'timeframe'
 			}
 		}
 		return {
 			property: dimension,
-			values: Object.keys(this._data.result.reduce((obj, res) => {
+			values: Object.keys(this._rawData.result.reduce((obj, res) => {
 				obj[res[dimension]] = true;
 				return obj;
 			}, {})).sort()
@@ -40,7 +40,7 @@ function tabulate () {
 	})
 
 	var data = {};
-	var points = this._data.result;
+	var points = this._rawData.result;
 	var i = points.length;
 	var res;
 	var coords;
@@ -67,7 +67,7 @@ function tabulate () {
 	}
 	/* eslint-enable */
 
-	return new Table({
+	return new ImmutableMatrix({
 		axes: axes,
 		interval: this.intervalUnit,
 		valueLabel: this.valueLabel,
@@ -78,9 +78,9 @@ function tabulate () {
 
 function prepIntervalData () {
 	let result;
-	if (Array.isArray(this._data.result[0].value) && ['object', 'undefined'].indexOf(typeof this._data.result[0].value[0]) > -1) {
+	if (Array.isArray(this._rawData.result[0].value) && ['object', 'undefined'].indexOf(typeof this._rawData.result[0].value[0]) > -1) {
 			// group by interval and prop
-			result = this._data.result.reduce((normalizedResults, snapshot) => {
+			result = this._rawData.result.reduce((normalizedResults, snapshot) => {
 				return normalizedResults.concat(snapshot.value.map(obj => {
 					obj.timeframe = snapshot.timeframe;
 					return obj;
@@ -88,7 +88,7 @@ function prepIntervalData () {
 			}, []);
 	} else {
 		// group by interval but not by prop
-		result = this._data.result.map(snapshot => {
+		result = this._rawData.result.map(snapshot => {
 			return {
 				result: snapshot.value,
 				timeframe: snapshot.timeframe
@@ -98,13 +98,13 @@ function prepIntervalData () {
 
 	return {
 		result: result,
-		timeframes: this._data.result.map(snapshot => snapshot.timeframe)
+		timeframes: this._rawData.result.map(snapshot => snapshot.timeframe)
 	}
 }
 
 module.exports = function () {
 	if (this.dimensions.indexOf('timeframe') > -1) {
-		this._data = prepIntervalData.call(this);
+		this._rawData = prepIntervalData.call(this);
 	}
-	return tabulate.call(this);
+	return immutifyKeen.call(this);
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,12 +23,16 @@ function build (queryConf, name) {
 	}, keenQuery);
 }
 
+
 module.exports = KeenQuery;
+
 module.exports.Aggregator = Aggregator;
 module.exports.defineAggregator = (name, constructor) => {
 	return Aggregator.define(name, constructor);
 }
+
 module.exports.aggregate = Aggregator.aggregate;
 module.exports.build = build;
 module.exports.execute = str => build(str).print();
+
 module.exports.parseFilter = parser.parseFilter;

--- a/lib/keen-query/index.js
+++ b/lib/keen-query/index.js
@@ -418,6 +418,10 @@ class KeenQuery {
 		return this._matrix;
 	}
 
+	getTable (dateStyle) {
+		return this._matrix.unflatten(dateStyle);
+	}
+
 	clone (withData) {
 		const kq = new KeenQuery();
 		kq.query = Object.assign({}, this.query);

--- a/lib/keen-query/index.js
+++ b/lib/keen-query/index.js
@@ -5,22 +5,19 @@ const immutifyKeen = require('../data/immutify-keen');
 const ImmutableMatrix = require('../data/immutable-matrix');
 const URL = require('url');
 const printers = require('../printers');
-const configContainer = process.browser ? window : process.env;
 const mappings = require('../mappings');
 const parser = require('../parser');
-if (!configContainer || !configContainer.KEEN_PROJECT_ID || !configContainer.KEEN_READ_KEY) {
-	console.log('Make sure you have KEEN_READ_KEY and KEEN_PROJECT_ID env vars set.');
-	process.exit(1);
-}
 
-let fetchOptions = {};
-let fetchHandler = res => res.json();
+let config = {
+	fetchHandler: res => res.json()
+};
+
 class KeenQuery {
 	constructor (event) {
 		this.dimensions = [];
 		this.groupedBy = [];
 		if (typeof event === 'object') {
-			throw new Error('THIS DOESN\'T work any more. If you need it to, nag rhys');
+			throw new Error('This doesn\'t work any more. If you need it to, nag rhys');
 			this.query = event.query || {};
 			this.extraction = event.extraction;
 			this.filters = event.filters;
@@ -299,7 +296,7 @@ class KeenQuery {
 	generateKeenUrl (base, format) {
 		format = typeof format === 'undefined' ? 'api' : format
 		if (format === 'api') {
-			base = typeof base === 'undefined' ? `${configContainer.KEEN_HOST || 'https://api.keen.io/3.0'}/projects/${configContainer.KEEN_PROJECT_ID}/queries/${this.extraction}?api_key=${configContainer.KEEN_READ_KEY}&`: base;
+			base = typeof base === 'undefined' ? `${config.KEEN_HOST || 'https://api.keen.io/3.0'}/projects/${config.KEEN_PROJECT_ID}/queries/${this.extraction}?api_key=${config.KEEN_READ_KEY}&`: base;
 			base += `${querystring.stringify(this.query)}`;
 			const parts = [base];
 			const complexQueryParts = this.buildComplexQueryParts()
@@ -402,8 +399,8 @@ class KeenQuery {
 			return Promise.resolve(printers.call(this, style))
 		}
 
-		return fetch(url, fetchOptions)
-			.then(fetchHandler)
+		return fetch(url, config.fetchOptions)
+			.then(config.fetchHandler)
 			.then(data => {
 				this._rawData = data;
 
@@ -464,12 +461,12 @@ class KeenQuery {
 		KeenQuery.prototype[name] = queryFunc;
 	}
 
-	static setFetchOptions (obj) {
-		fetchOptions = obj;
+	static setConfig (obj) {
+		config = Object.assign(config, obj);
 	}
 
-	static setFetchHandler (func) {
-		fetchHandler = func;
+	static getConfig () {
+		return config;
 	}
 
 }

--- a/lib/keen-query/index.js
+++ b/lib/keen-query/index.js
@@ -1,8 +1,8 @@
 'use strict';
 require('isomorphic-fetch');
 const querystring = require('querystring');
-const tabulate = require('../tabulate');
-const Table = require('../table');
+const immutifyKeen = require('../data/immutify-keen');
+const ImmutableMatrix = require('../data/immutable-matrix');
 const URL = require('url');
 const printers = require('../printers');
 const configContainer = process.browser ? window : process.env;
@@ -260,7 +260,7 @@ class KeenQuery {
 	}
 
 	_getInstance (withData) {
-		if (this._data) {
+		if (this._rawData) {
 			return this.clone(withData);
 		}
 		return this;
@@ -410,31 +410,27 @@ class KeenQuery {
 			return Promise.resolve(url);
 		}
 
-		if (this._data) {
+		if (this._rawData) {
 			return Promise.resolve(printers.call(this, style))
 		}
 
 		return fetch(url, fetchOptions)
 			.then(fetchHandler)
 			.then(data => {
-				this._data = data;
+				this._rawData = data;
 
-				this._table = this._tabulate(data);
+				this._matrix = immutifyKeen.call(this)
 				if (this._postProcessors) {
 					this._postProcessors.forEach(opts => {
-						this._table = this.getTable()[opts.func].apply(this.getTable(), opts.params);
+						this._matrix = this.getData()[opts.func].apply(this.getData(), opts.params);
 					})
 				}
 				return printers.call(this, style);
 			});
 	}
 
-	_tabulate () {
-		return tabulate.apply(this, [].slice.call(arguments))
-	}
-
-	getTable () {
-		return this._table;
+	getData () {
+		return this._matrix;
 	}
 
 	clone (withData) {
@@ -451,9 +447,9 @@ class KeenQuery {
 		kq.excludeNulls = this.excludeNulls;
 		kq.groupedBy = this.groupedBy.slice();
 		kq._printer = this._printer;
-		if (withData && this._data) {
-			kq._data = this._data;
-			kq._table = this.getTable().clone();
+		if (withData && this._rawData) {
+			kq._rawData = this._rawData;
+			kq._matrix = this.getData().clone();
 		}
 		return kq;
 	}
@@ -496,6 +492,6 @@ class KeenQuery {
 }
 
 // mixin all the table methods
-Table.mixin(KeenQuery.prototype)
+ImmutableMatrix.mixin(KeenQuery.prototype)
 
 module.exports = KeenQuery;

--- a/lib/keen-query/index.js
+++ b/lib/keen-query/index.js
@@ -13,7 +13,6 @@ if (!configContainer || !configContainer.KEEN_PROJECT_ID || !configContainer.KEE
 	process.exit(1);
 }
 
-const forcedQueries = [];
 let fetchOptions = {};
 let fetchHandler = res => res.json();
 class KeenQuery {
@@ -30,7 +29,6 @@ class KeenQuery {
 				event_collection: event
 			};
 			this.filters = [];
-			this.forcedQueries = forcedQueries;
 		}
 
 	}
@@ -100,12 +98,6 @@ class KeenQuery {
 		this._setExtraction('select_unique');
 		this.query.target_property = prop;
 		return this;
-	}
-
-	raw () {
-		const instance = this._getInstance();
-		instance.forcedQueries = [];
-		return instance;
 	}
 
 	tidy (extraStrict) {
@@ -389,10 +381,6 @@ class KeenQuery {
 
 		style = style || this._printer;
 
-		this.forcedQueries.forEach(q => {
-			q.apply(this);
-		});
-
 		if (!this.timeframe) {
 			this.relTime();
 		}
@@ -438,7 +426,6 @@ class KeenQuery {
 		kq.query = Object.assign({}, this.query);
 		kq.extraction = this.extraction;
 		kq.filters = this.filters.slice().map(f => Object.assign({}, f));
-		kq.forcedQueries = this.forcedQueries && this.forcedQueries.slice().map(f => Object.assign({}, f));
 		kq._postProcessors = this._postProcessors && this._postProcessors.slice().map(f => Object.assign({}, f));
 		kq.timeframe = typeof this.timeframe === 'string' ? this.timeframe :
 									typeof this.timeframe === 'object' ? Object.assign({}, this.timeframe) : undefined;
@@ -475,10 +462,6 @@ class KeenQuery {
 
 	static defineQuery (name, queryFunc) {
 		KeenQuery.prototype[name] = queryFunc;
-	}
-
-	static forceQuery (queryFunc) {
-		forcedQueries.push[queryFunc];
 	}
 
 	static setFetchOptions (obj) {

--- a/lib/post-processing/cutoff.js
+++ b/lib/post-processing/cutoff.js
@@ -4,7 +4,7 @@ module.exports.cutoff = function (n, strategy, dimension) {
 	const refMatrix = strategy ? matrix.reduce(strategy, dimension) : matrix;
 	const axis = dimension ? matrix.getAxis(dimension) : 0;
 	if (typeof n === 'string' && n.substr(-1) === '%') {
-		n = refMatrix.reduce('sum').data * n.slice(0, -1) / 100;
+		n = refMatrix.reduce(axis, 'sum').data * n.slice(0, -1) / 100;
 	}
 
 

--- a/lib/post-processing/cutoff.js
+++ b/lib/post-processing/cutoff.js
@@ -1,56 +1,64 @@
 
-module.exports.cutoff = function (n, percentOrRaw, strategy, dimension) {
-	const table = this.sortDesc(strategy, dimension);
-	const refTable = strategy ? table.reduce(strategy, dimension) : table;
-	const axis = dimension ? table.getAxis(dimension) : 0;
-	if (percentOrRaw === 'percent') {
-		n = refTable.reduce('sum').data * n / 100;
+module.exports.cutoff = function (n, strategy, dimension) {
+	const matrix = this.sortDesc(strategy, dimension);
+	const refMatrix = strategy ? matrix.reduce(strategy, dimension) : matrix;
+	const axis = dimension ? matrix.getAxis(dimension) : 0;
+	if (typeof n === 'string' && n.substr(-1) === '%') {
+		n = refMatrix.reduce('sum').data * n.slice(0, -1) / 100;
 	}
+
+
 	const map = {};
-	if (refTable !== table) {
+	if (refMatrix !== matrix) {
 		throw new Error('TODO: handle cutoff based on some calculation of many values')
 	}
-	table.cellIterator((value, coords) => {
+	matrix.cellIterator((value, coords) => {
 		if (value >= n) {
 			map[coords] = value;
 		}
 	})
-	table.data = map;
-	table.axes[axis].values = table.axes[axis].values.slice(0, Object.keys(table.data).length);
-	return table;
+	matrix.data = map;
+	matrix.axes[axis].values = matrix.axes[axis].values.slice(0, Object.keys(matrix.data).length);
+	return matrix;
 }
 
-module.exports.top = function (n, percentOrRaw, strategy, dimension) {
-	const table = this.sortDesc(strategy, dimension);
-	const axis = dimension ? table.getAxis(dimension) : 0;
-	if (percentOrRaw === 'percent') {
-		n = n * table.size[axis] / 100
-	}
+module.exports.top = function (n, strategy, dimension) {
+	const matrix = this.sortDesc(strategy, dimension);
+	const axis = dimension ? matrix.getAxis(dimension) : 0;
+	n = depercentify(n, matrix, axis);
 	const map = {};
 
-	table.cellIterator((value, coords) => {
+	matrix.cellIterator((value, coords) => {
 		if (Number(coords.split(',')[axis]) < n) {
 			map[coords] = value;
 		}
 	})
-	table.data = map;
-	table.axes[axis].values = table.axes[axis].values.slice(0, n);
-	return table;
+	matrix.data = map;
+	matrix.axes[axis].values = matrix.axes[axis].values.slice(0, n);
+	return matrix;
 }
 
-module.exports.bottom = function (n, percentOrRaw, strategy, dimension) {
-	const table = this.sortAsc(strategy, dimension);
-	const axis = dimension ? table.getAxis(dimension) : 0;
-	if (percentOrRaw === 'percent') {
-		n = n * table.size[axis] / 100
-	}
+
+
+module.exports.bottom = function (n, strategy, dimension) {
+	const matrix = this.sortAsc(strategy, dimension);
+	const axis = dimension ? matrix.getAxis(dimension) : 0;
+	n = depercentify(n, matrix, axis);
+
 	const map = {};
-	table.cellIterator((value, coords) => {
+	matrix.cellIterator((value, coords) => {
 		if (Number(coords.split(',')[axis]) < n) {
 			map[coords] = value;
 		}
 	})
-	table.data = map;
-	table.axes[axis].values = table.axes[axis].values.slice(0, n);
-	return table;
+	matrix.data = map;
+	matrix.axes[axis].values = matrix.axes[axis].values.slice(0, n);
+	return matrix;
+}
+
+function depercentify (n, matrix, axis) {
+	if (typeof n === 'string' && n.substr(-1) === '%') {
+		n = Number(n.slice(0, -1)) * matrix.size[axis] / 100
+	}
+	return n;
 }

--- a/lib/post-processing/index.js
+++ b/lib/post-processing/index.js
@@ -30,7 +30,7 @@ const postProcessors = {
 	reduce: reduce.reduce,
 	sortAsc: sort.ascending,
 	sortDesc: sort.descending,
-	sortProp: sort.property,
+	reorder: sort.property,
 	plotThreshold: threshold.threshold,
 	cutoff: cutoff.cutoff,
 	top: cutoff.top,

--- a/lib/post-processing/reduce.js
+++ b/lib/post-processing/reduce.js
@@ -55,7 +55,7 @@ const strategiesMap = {
 	}
 };
 
-module.exports.reduce = function (strategy, dimension, concat) {
+module.exports.reduce = function (dimension, strategy, concat) {
 	dimension = typeof dimension === 'undefined' ? this.dimension - 1 : this.getAxis(dimension);
 	let matrix = this;
 	if (dimension !== this.dimension - 1) {

--- a/lib/post-processing/reduce.js
+++ b/lib/post-processing/reduce.js
@@ -57,12 +57,12 @@ const strategiesMap = {
 
 module.exports.reduce = function (strategy, dimension, concat) {
 	dimension = typeof dimension === 'undefined' ? this.dimension - 1 : this.getAxis(dimension);
-	let table = this;
+	let matrix = this;
 	if (dimension !== this.dimension - 1) {
-		table = this.switchDimensions(dimension, null, 'shuffle');
+		matrix = this.switchDimensions(dimension, null, 'shuffle');
 	}
-	let buckets = table.toNested(1, 'bottom');
-	const axes = table.axes.slice();
+	let buckets = matrix.toNested(1, 'bottom');
+	const axes = matrix.axes.slice();
 	const removedAxis = axes.pop();
 	if (strategy === 'all') {
 
@@ -81,7 +81,7 @@ module.exports.reduce = function (strategy, dimension, concat) {
 		})
 	} else {
 
-		if (buckets['']) { // this is just what happens when the table starts off as one column and is reduced to a single value
+		if (buckets['']) { // this is just what happens when the matrix starts off as one column and is reduced to a single value
 			buckets = strategiesMap[strategy](buckets[''])
 		} else {
 			Object.keys(buckets).forEach(k => { // in all other cases the values have sensible labels
@@ -90,24 +90,24 @@ module.exports.reduce = function (strategy, dimension, concat) {
 		}
 	}
 
-	const reducedTable = table.clone({
+	const reducedMatrix = matrix.clone({
 		axes,
 		data: buckets
 	});
 
 	if (strategy !== 'all') {
-		reducedTable.valueLabel = `${reducedTable.valueLabel} (${strategy}: ${removedAxis.property})`;
+		reducedMatrix.valueLabel = `${reducedMatrix.valueLabel} (${strategy}: ${removedAxis.property})`;
 	}
 
 	if (concat) {
-		return concatUtil([table.clone(), reducedTable]);
+		return concatUtil([matrix.clone(), reducedMatrix]);
 	}
 
 	if (removedAxis.property === 'timeframe') {
-		reducedTable.interval = null;
+		reducedMatrix.interval = null;
 	}
 
-	return reducedTable
+	return reducedMatrix
 }
 
 module.exports.reduceStrategies = strategiesMap;

--- a/lib/post-processing/sort.js
+++ b/lib/post-processing/sort.js
@@ -1,7 +1,7 @@
 'use strict';
 
 function getReferenceTable(table, direction) {
-	return table.humanize().rows.sort((r1, r2) => {
+	return table.unflatten().rows.sort((r1, r2) => {
 		return (r1[1] > r2[1] ? 1 : r1[1] < r2[1] ? -1 : 0) * (direction === 'desc' ? -1 : 1);
 	});
 }
@@ -45,7 +45,7 @@ module.exports.descending = function (strategy, dimension) {
 
 
 function getReferenceTable(table, direction) {
-	return table.humanize().rows.sort((r1, r2) => {
+	return table.unflatten().rows.sort((r1, r2) => {
 		return (r1[1] > r2[1] ? 1 : r1[1] < r2[1] ? -1 : 0) * (direction === 'desc' ? -1 : 1);
 	});
 }

--- a/lib/post-processing/sort.js
+++ b/lib/post-processing/sort.js
@@ -1,24 +1,24 @@
 'use strict';
 
-function getReferenceTable(table, direction) {
-	return table.unflatten().rows.sort((r1, r2) => {
+function getReferenceMatrix(matrix, direction) {
+	return matrix.unflatten().rows.sort((r1, r2) => {
 		return (r1[1] > r2[1] ? 1 : r1[1] < r2[1] ? -1 : 0) * (direction === 'desc' ? -1 : 1);
 	});
 }
 
-function simpleSort(table, direction) {
-	const referenceTable = getReferenceTable(table, direction);
+function simpleSort(matrix, direction) {
+	const referenceMatrix = getReferenceMatrix(matrix, direction);
 
-	return table.clone({
+	return matrix.clone({
 		axes: [
-			Object.assign({}, table.axes[0], {values: referenceTable.map(r => r[0])})
+			Object.assign({}, matrix.axes[0], {values: referenceMatrix.map(r => r[0])})
 		],
-		data: referenceTable.map(r => r[1])
+		data: referenceMatrix.map(r => r[1])
 	});
 }
 
-function complexSort () {//table, direction, strategy, dimension) {
-	// const referenceTable = getReferenceTable(table.reduce(strategy, dimension), direction);
+function complexSort () {//matrix, direction, strategy, dimension) {
+	// const referenceMatrix = getReferenceMatrix(matrix.reduce(strategy, dimension), direction);
 }
 
 module.exports.ascending = function (strategy, dimension) {
@@ -44,20 +44,20 @@ module.exports.descending = function (strategy, dimension) {
 }
 
 
-function getReferenceTable(table, direction) {
-	return table.unflatten().rows.sort((r1, r2) => {
+function getReferenceMatrix(matrix, direction) {
+	return matrix.unflatten().rows.sort((r1, r2) => {
 		return (r1[1] > r2[1] ? 1 : r1[1] < r2[1] ? -1 : 0) * (direction === 'desc' ? -1 : 1);
 	});
 }
 
-function simpleSort(table, direction) {
-	const referenceTable = getReferenceTable(table, direction);
+function simpleSort(matrix, direction) {
+	const referenceMatrix = getReferenceMatrix(matrix, direction);
 
-	return table.clone({
+	return matrix.clone({
 		axes: [
-			Object.assign({}, table.axes[0], {values: referenceTable.map(r => r[0])})
+			Object.assign({}, matrix.axes[0], {values: referenceMatrix.map(r => r[0])})
 		],
-		data: referenceTable.map(r => r[1])
+		data: referenceMatrix.map(r => r[1])
 	});
 }
 

--- a/lib/post-processing/threshold.js
+++ b/lib/post-processing/threshold.js
@@ -8,14 +8,14 @@ module.exports.threshold = function (value, name) {
 		throw new Error ('setting thresholds only supported for graphs that track trend over time. Maybe you want ->target()')
 	}
 
-	const thresholdTable = this.clone();
+	const thresholdMatrix = this.clone();
 
-	thresholdTable.axes = [thresholdTable.axes[this.timeHeadingsLocation]];
-	thresholdTable.valueLabel = name;
+	thresholdMatrix.axes = [thresholdMatrix.axes[this.timeHeadingsLocation]];
+	thresholdMatrix.valueLabel = name;
 
-	thresholdTable.data = thresholdTable.axes[0].values.reduce((obj, val, i) => {
+	thresholdMatrix.data = thresholdMatrix.axes[0].values.reduce((obj, val, i) => {
 		obj[i] = value;
 		return obj;
 	}, {})
-	return concatUtil([this, thresholdTable]);
+	return concatUtil([this, thresholdMatrix]);
 }

--- a/lib/printers/ascii.js
+++ b/lib/printers/ascii.js
@@ -3,20 +3,20 @@ const AsciiTable = require('ascii-table');
 
 function ascii () {
 
-	let table = this.getTable();
+	let table = this.getData();
 
 	// make sure the greatest dimension is shown vertically
 	// TODO: base it on total text length rather than number of columns/rows
 	if (table.dimension === 2) {
 		const greatestDimension = table.size.reduce((max, s, i) => {
-			if (s > this.getTable().size[max]) {
+			if (s > this.getData().size[max]) {
 				return i;
 			}
 			return max;
 		}, 0);
 		table = table.switchDimensions(greatestDimension, 0, 'swap');
 	}
-	const data = table.humanize('shortISO');
+	const data = table.unflatten('shortISO');
 	const asciiTable = new AsciiTable(this.name + ': ' + this.toString());
 	asciiTable.setHeading.apply(asciiTable, data.headings);
 	data.rows.forEach(r => asciiTable.addRow.apply(asciiTable, r));

--- a/lib/printers/index.js
+++ b/lib/printers/index.js
@@ -1,17 +1,17 @@
 const printers = {
 	raw: function () {
-		return this._data;
+		return this._rawData;
 	},
 
 	json: function () {
-		return this.getTable().humanize();
+		return this.getData().unflatten();
 	},
 
 	csv: function () {
 
 	},
 	tsv: function () {
-		const table = this.getTable().humanize('human');
+		const table = this.getData().unflatten('human');
 		const rows = table.headings ? [table.headings] : []
 		return rows.concat(table.rows)
 				.map(row => row.join('\t'))
@@ -27,7 +27,7 @@ const printers = {
 // }
 
 module.exports = function (style) {
-	if (!this._table && style !== 'raw') {
+	if (!this._matrix && style !== 'raw') {
 		throw new Error('Not printable');
 	}
 	const renderer = printers[style] || printers.json;

--- a/lib/todo-reapply-these-validation-ruless.js
+++ b/lib/todo-reapply-these-validation-ruless.js
@@ -103,7 +103,7 @@
 
 
 
-// 	if (['sortAsc', 'sortDesc', 'plotThreshold', 'cutoff', 'top', 'bottom', 'sortProp', 'relabel'].indexOf(name) > -1) {
+// 	if (['sortAsc', 'sortDesc', 'plotThreshold', 'cutoff', 'top', 'bottom', 'reorder', 'relabel'].indexOf(name) > -1) {
 // 		return isValidStructure;
 // 		// return isValidStructure && validateSort(conf);
 // 	}

--- a/test/data-manipulation.js
+++ b/test/data-manipulation.js
@@ -432,7 +432,7 @@ describe('Data manipulation', () => {
 			it('should discard values smaller than a percentage of the total', () => {
 				fetchMock
 					.mock(/potato/, mockKeenData(8));
-				return testQuery('potato->count()->group(prop0)->cutoff(10,percent)',
+				return testQuery('potato->count()->group(prop0)->cutoff(10%)',
 					{"headings":["prop0","count potato"],"rows":[["prop0-7",7],["prop0-6",6],["prop0-5",5],["prop0-4",4],["prop0-3",3]]})
 			});
 
@@ -451,7 +451,7 @@ describe('Data manipulation', () => {
 			it('should show top n percent of values', () => {
 				fetchMock
 					.mock(/potato/, mockKeenData(8));
-				return testQuery('potato->count()->group(prop0)->top(40,percent)',
+				return testQuery('potato->count()->group(prop0)->top(40%)',
 					{"headings":["prop0","count potato"],"rows":[["prop0-7",7],["prop0-6",6],["prop0-5",5]]});
 			});
 
@@ -465,7 +465,7 @@ describe('Data manipulation', () => {
 			it('should show bottom n percent of values', () => {
 				fetchMock
 					.mock(/potato/, mockKeenData(8));
-				return testQuery('potato->count()->group(prop0)->bottom(40,percent)',
+				return testQuery('potato->count()->group(prop0)->bottom(40%)',
 					{"headings":["prop0","count potato"],"rows":[["prop0-0",0],["prop0-1",1],["prop0-2",2]]});
 			});
 
@@ -482,7 +482,7 @@ describe('Data manipulation', () => {
 		it('can do complex stuff with data grouped by date', () => {
 			fetchMock
 				.mock(/page%3Aview/, dateData);
-			return testQuery('page:view->count()->interval(d)->bottom(40,percent)',
+			return testQuery('page:view->count()->interval(d)->bottom(40%)',
 				{"headings":["timeframe","count page:view"],"rows":[[{"start":"2016-03-26T00:00:00.000Z","end":"2016-03-27T00:00:00.000Z"},14114],[{"start":"2016-04-03T00:00:00.000Z","end":"2016-04-04T00:00:00.000Z"},14813],[{"start":"2016-04-02T00:00:00.000Z","end":"2016-04-03T00:00:00.000Z"},14916],[{"start":"2016-03-27T00:00:00.000Z","end":"2016-03-28T00:00:00.000Z"},14919],[{"start":"2016-03-25T00:00:00.000Z","end":"2016-03-26T00:00:00.000Z"},24718]]});
 		});
 

--- a/test/data-manipulation.js
+++ b/test/data-manipulation.js
@@ -198,7 +198,7 @@ describe('Data manipulation', () => {
 			it('will reduce a column', () => {
 				fetchMock
 					.mock(/potato/, mockKeenData(3));
-				return testQuery('potato->count()->group(prop0)->reduce(sum,prop0)',
+				return testQuery('potato->count()->group(prop0)->reduce(prop0,sum)',
 					{"rows":[["count potato (sum: prop0)",3]]})
 			});
 
@@ -206,77 +206,77 @@ describe('Data manipulation', () => {
 			it('will reduce a table by first dimension', () => {
 				fetchMock
 					.mock(/potato/, mockKeenData(3, 3));
-				return testQuery('potato->count()->group(prop0,prop1)->reduce(sum,prop0)',
+				return testQuery('potato->count()->group(prop0,prop1)->reduce(prop0,sum)',
 					{"headings":["prop1","count potato (sum: prop0)"],"rows":[["prop1-0",30],["prop1-1",33],["prop1-2",36]]});
 			});
 
 			it('will reduce a table by second dimension', () => {
 				fetchMock
 					.mock(/potato/, mockKeenData(3, 3));
-				return testQuery('potato->count()->group(prop0,prop1)->reduce(sum,prop1)',
+				return testQuery('potato->count()->group(prop0,prop1)->reduce(prop1,sum)',
 					{"headings":["prop0","count potato (sum: prop1)"],"rows":[["prop0-0",3],["prop0-1",33],["prop0-2",63]]});
 			});
 
 			it('will reduce a higher order table by choice of dimension', () => {
 				fetchMock
 					.mock(/potato/, mockKeenData(3, 3, 4));
-				return testQuery('potato->count()->group(prop0,prop1,prop2)->reduce(sum,prop1)',
+				return testQuery('potato->count()->group(prop0,prop1,prop2)->reduce(prop1,sum)',
 					{"headings":["prop0","prop2-0","prop2-1","prop2-2","prop2-3"],"rows":[["prop0-0",30,33,36,39],["prop0-1",330,333,336,339],["prop0-2",630,633,636,639]]});
 			});
 
 			it('will average', () => {
 				fetchMock
 					.mock(/potato/, mockKeenData(8));
-				return testQuery('potato->count()->group(prop0)->reduce(avg,prop0)',
+				return testQuery('potato->count()->group(prop0)->reduce(prop0,avg)',
 					{"rows":[["count potato (avg: prop0)",3.5]]})
 			});
 
 			it('will sum', () => {
 				fetchMock
 					.mock(/potato/, mockKeenData(8));
-				return testQuery('potato->count()->group(prop0)->reduce(sum,prop0)',
+				return testQuery('potato->count()->group(prop0)->reduce(prop0,sum)',
 					{"rows":[["count potato (sum: prop0)",28]]})
 			});
 
 			it('will find minimum', () => {
 				fetchMock
 					.mock(/potato/, mockKeenData(8));
-				return testQuery('potato->count()->group(prop0)->reduce(min,prop0)',
+				return testQuery('potato->count()->group(prop0)->reduce(prop0,min)',
 					{"rows":[["count potato (min: prop0)",0]]})
 			});
 
 			it('will find maximum', () => {
 				fetchMock
 					.mock(/potato/, mockKeenData(8));
-				return testQuery('potato->count()->group(prop0)->reduce(max,prop0)',
+				return testQuery('potato->count()->group(prop0)->reduce(prop0,max)',
 					{"rows":[["count potato (max: prop0)",7]]})
 			});
 
 			it('will find median', () => {
 				fetchMock
 					.mock(/potato/, mockKeenData(7));
-				return testQuery('potato->count()->group(prop0)->reduce(median,prop0)',
+				return testQuery('potato->count()->group(prop0)->reduce(prop0,median)',
 					{"rows":[["count potato (median: prop0)",3]]})
 			});
 
 			it.skip('will find nth percentile', () => {
 				fetchMock
 					.mock(/potato/, mockKeenData(8));
-				return testQuery('potato->count()->group(prop0)->reduce(pct,25,prop0)',
+				return testQuery('potato->count()->group(prop0)->reduce(prop0,pct,25)',
 					{"rows":[["count potato (sum: prop0)",2]]})
 			});
 
 			it('will calculate % change between last two values', () => {
 				fetchMock
 					.mock(/potato/, mockKeenData(6));
-				return testQuery('potato->count()->group(prop0)->reduce(%change,prop0)',
+				return testQuery('potato->count()->group(prop0)->reduce(prop0,%change)',
 					{"rows":[["count potato (%change: prop0)",25]]})
 			});
 
 			it('will calculate trend', () => {
 				fetchMock
 					.mock(/potato/, multiply(5, mockKeenData(8)));
-				return testQuery('potato->count()->group(prop0)->reduce(trend,prop0)',
+				return testQuery('potato->count()->group(prop0)->reduce(prop0,trend)',
 					{"rows":[["count potato (trend: prop0)", 5]]})
 			});
 
@@ -285,14 +285,14 @@ describe('Data manipulation', () => {
 				it('will calculate all trivial reductions on a column', () => {
 					fetchMock
 						.mock(/potato/, mockKeenData(3));
-					return testQuery('potato->count()->group(prop0)->reduce(all,prop0)',
+					return testQuery('potato->count()->group(prop0)->reduce(prop0,all)',
 						{"headings":[undefined,"count potato"],"rows":[["avg",1],["min",0],["max",2],["median",1],["sum",3],["trend",1],["%change",100]]})
 				})
 
 				it('will calculate all trivial reductions on a table', () => {
 					fetchMock
 						.mock(/potato/, mockKeenData(3, 3));
-					return testQuery('potato->count()->group(prop0,prop1)->reduce(all,prop0)',
+					return testQuery('potato->count()->group(prop0,prop1)->reduce(prop0,all)',
 						{"headings":["prop1","avg","min","max","median","sum","trend","%change"],"rows":[["prop1-0",10,0,20,10,30,10,100],["prop1-1",11,1,21,11,33,10,90.9090909090909],["prop1-2",12,2,22,2,36,5,1000]]});
 				})
 			})
@@ -300,7 +300,7 @@ describe('Data manipulation', () => {
 			it('will append result to existing table if requested', () => {
 				fetchMock
 					.mock(/potato/, mockKeenData(3));
-				return testQuery('potato->count()->group(prop0)->reduce(sum,prop0,true)',
+				return testQuery('potato->count()->group(prop0)->reduce(prop0,sum,true)',
 					{"headings":["prop0","count potato"],"rows":[["prop0-0",0],["prop0-1",1],["prop0-2",2],["count potato (sum: prop0)",3]]})
 			});
 		})
@@ -505,13 +505,13 @@ describe('Data manipulation', () => {
 		it.skip('can concat data grouped by property to data grouped by date and property', () => {
 			fetchMock
 				.mock(/page%3Aview.*group/, dateDeviceData);
-			return testQuery('@concat(page:view->count()->group(device.primaryHardwareType), page:view->count()->group(device.primaryHardwareType)->reduce(max,timeframe))->interval(d)');
+			return testQuery('@concat(page:view->count()->group(device.primaryHardwareType), page:view->count()->group(device.primaryHardwareType)->reduce(timeframe,max))->interval(d)');
 		});
 
 		it('can do complex stuff with data grouped by date and other properties', () => {
 			fetchMock
 				.mock(/page%3Aview/, dateDeviceLayoutData)
-			return testQuery('page:view->count()->group(device.primaryHardwareType,device.oGridLayout)->interval(d)->reduce(avg,device.oGridLayout)->reduce(max,timeframe)',
+			return testQuery('page:view->count()->group(device.primaryHardwareType,device.oGridLayout)->interval(d)->reduce(device.oGridLayout,avg)->reduce(timeframe,max)',
 				{"headings":["device.primaryHardwareType","count page:view (avg: device.oGridLayout) (max: timeframe)"],"rows":[["Desktop",845967.5555555555],["Mobile Phone",82384.55555555556],["Tablet",88403.11111111111]]});
 
 		});

--- a/test/data-manipulation.js
+++ b/test/data-manipulation.js
@@ -1,6 +1,10 @@
 'use strict';
 
-// const KeenQuery = require('../lib');
+const KeenQuery = require('../lib');
+KeenQuery.setConfig({
+	KEEN_PROJECT_ID: 'test_proj',
+	KEEN_READ_KEY: 'test_key'
+});
 // const expect = require('chai').expect;
 const fetchMock = require('fetch-mock');
 const mockKeenData = require('./helpers').mockKeenData;

--- a/test/data-manipulation.js
+++ b/test/data-manipulation.js
@@ -121,7 +121,7 @@ describe('Data manipulation', () => {
 					.mock(/tomato/, {result: 2})
 					.mock(/apple/, {result: 3});
 				return testQuery('@concat(potato->count(),tomato->count(),apple->count())',
-					{"headings":["CONCATENATION_RESULT",undefined],"rows":[["count potato",1],["count tomato",2],["count apple",3]]})
+					{"headings":["_headings",undefined],"rows":[["count potato",1],["count tomato",2],["count apple",3]]})
 			});
 
 
@@ -358,14 +358,14 @@ describe('Data manipulation', () => {
 			it('should be possible to reorder a column', () => {
 				fetchMock
 					.mock(/potato/, mockKeenData(5));
-				return testQuery('potato->count()->group(prop0)->sortProp(prop0,prop0-4,prop0-2)',
+				return testQuery('potato->count()->group(prop0)->reorder(prop0,prop0-4,prop0-2)',
 					{"headings":["prop0","count potato"],"rows":[["prop0-4",4],["prop0-2",2],["prop0-0",0],["prop0-1",1],["prop0-3",3]]});
 			});
 
 			it('should be possible to reorder a table', () => {
 				fetchMock
 					.mock(/potato/, mockKeenData(5,4));
-				return testQuery('potato->count()->group(prop0,prop1)->sortProp(prop1,prop1-3,prop1-2)->sortProp(prop0,prop0-4,prop0-2)',
+				return testQuery('potato->count()->group(prop0,prop1)->reorder(prop1,prop1-3,prop1-2)->reorder(prop0,prop0-4,prop0-2)',
 					{"headings":["prop0","prop1-3","prop1-2","prop1-0","prop1-1"],"rows":[["prop0-4",43,42,40,41],["prop0-2",23,22,20,21],["prop0-0",3,2,0,1],["prop0-1",13,12,10,11],["prop0-3",33,32,30,31]]});
 			});
 
@@ -498,7 +498,7 @@ describe('Data manipulation', () => {
 			fetchMock
 				.mock(/page%3Aview.*group/, dateDeviceData)
 				.mock(/page%3Aview/, dateData);
-			return testQuery('@concat(page:view->count()->group(device.primaryHardwareType), page:view->count())->interval(d)->sortProp(device.primaryHardwareType,count page:view)->relabel(device.primaryHardwareType,total)',
+			return testQuery('@concat(page:view->count()->group(device.primaryHardwareType), page:view->count())->interval(d)->reorder(device.primaryHardwareType,count page:view)->relabel(device.primaryHardwareType,total)',
 				{"headings":["timeframe","total","Desktop","Mobile Phone","Tablet"],"rows":[[{"start":"2016-03-26T00:00:00.000Z","end":"2016-03-27T00:00:00.000Z"},24718,123813,123578,123165],[{"start":"2016-03-27T00:00:00.000Z","end":"2016-03-28T00:00:00.000Z"},14114,123965,123599,123142],[{"start":"2016-03-28T00:00:00.000Z","end":"2016-03-29T00:00:00.000Z"},14919,1231778,123717,123235],[{"start":"2016-03-29T00:00:00.000Z","end":"2016-03-30T00:00:00.000Z"},24812,1233186,123605,123180],[{"start":"2016-03-30T00:00:00.000Z","end":"2016-03-31T00:00:00.000Z"},34918,1232249,123657,123115],[{"start":"2016-03-31T00:00:00.000Z","end":"2016-04-01T00:00:00.000Z"},34215,1232022,123623,123173],[{"start":"2016-04-01T00:00:00.000Z","end":"2016-04-02T00:00:00.000Z"},34019,1232182,123627,123103],[{"start":"2016-04-02T00:00:00.000Z","end":"2016-04-03T00:00:00.000Z"},34211,123903,123421,123165],[{"start":"2016-04-03T00:00:00.000Z","end":"2016-04-04T00:00:00.000Z"},14916,1231045,123581,123198],[{"start":"2016-04-04T00:00:00.000Z","end":"2016-04-05T00:00:00.000Z"},14813,1233727,123921,123258],[{"start":"2016-04-05T00:00:00.000Z","end":"2016-04-06T00:00:00.000Z"},44910,1233585,123670,123253],[{"start":"2016-04-06T00:00:00.000Z","end":"2016-04-07T00:00:00.000Z"},44017,1233726,123802,123219],[{"start":"2016-04-07T00:00:00.000Z","end":"2016-04-08T00:00:00.000Z"},44111,1233654,123711,123274],[{"start":"2016-04-08T00:00:00.000Z","end":"2016-04-09T00:00:00.000Z"},34315,1231140,123221,12360]]});
 		});
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,5 +1,9 @@
 'use strict';
 const KeenQuery = require('../lib');
+KeenQuery.setConfig({
+	KEEN_PROJECT_ID: 'test_proj',
+	KEEN_READ_KEY: 'test_key'
+});
 const expect = require('chai').expect;
 
 // Numerical values always match coordinates e.g. the value in [1,0,3] will be 103

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -71,7 +71,7 @@ function log (data) {
 }
 
 module.exports.testQuery = function (kq, expected) {
-	const promise = KeenQuery.build(kq).print('json')
+	const promise = KeenQuery.build(kq).print('matrix')
 	if (!expected) {
 		promise.then(log)
 	}

--- a/test/keen-explorer-integration.test.js
+++ b/test/keen-explorer-integration.test.js
@@ -1,6 +1,10 @@
 'use strict'
 
-const KeenQuery = require('../lib/index.js')
+const KeenQuery = require('../lib');
+KeenQuery.setConfig({
+	KEEN_PROJECT_ID: 'test_proj',
+	KEEN_READ_KEY: 'test_key'
+});
 const expect = require('chai').expect
 
 describe.skip('converting explorer urls into keen queries', () => {

--- a/test/regression.test.js
+++ b/test/regression.test.js
@@ -1,4 +1,8 @@
 const KeenQuery = require('../lib');
+KeenQuery.setConfig({
+	KEEN_PROJECT_ID: 'test_proj',
+	KEEN_READ_KEY: 'test_key'
+});
 const Aggregator = require('../lib/aggregator');
 const expect = require('chai').expect;
 const fetchMock = require('fetch-mock');

--- a/test/regression.test.js
+++ b/test/regression.test.js
@@ -16,7 +16,7 @@ describe('regression tests', () => {
 		const kq = KeenQuery.build('potato->count()->group(prop0,prop1)');
 
 		return kq
-			.print('json')
+			.print('matrix')
 			.then(data1 => {
 				return kq.clone(true)
 					.print()
@@ -36,7 +36,7 @@ describe('regression tests', () => {
 		const kq = KeenQuery.build('@ratio(potato->count()->group(prop0,prop1),potato->count()->group(prop0,prop1))');
 
 		return kq
-			.print('json')
+			.print('matrix')
 			.then(data1 => {
 				return kq.clone(true)
 					.print()

--- a/test/regression.test.js
+++ b/test/regression.test.js
@@ -77,7 +77,7 @@ describe('regression tests', () => {
 		fetchMock
 			.mock(/potato/, mockKeenData({size: [3], props: ['timeframe']}));
 
-		return testQuery('@concat(@ratio(potato->count(),potato->count()),@pct(potato->count(),potato->count()))->interval(d)->relabel(CONCATENATION_RESULT,Home,World)',
+		return testQuery('@concat(@ratio(potato->count(),potato->count()),@pct(potato->count(),potato->count()))->interval(d)->relabel(_headings,Home,World)',
 			{"headings":["timeframe","Home","World"],"rows":[["timeframe-0",0,0],["timeframe-1",0,0],["timeframe-2",0,0]]})
 			.then(fetchMock.restore);
 	});

--- a/test/reusability.test.js
+++ b/test/reusability.test.js
@@ -1,6 +1,10 @@
 'use strict';
 
-const KeenQuery = require('../lib/index.js');
+const KeenQuery = require('../lib');
+KeenQuery.setConfig({
+	KEEN_PROJECT_ID: 'test_proj',
+	KEEN_READ_KEY: 'test_key'
+});
 const expect = require('chai').expect;
 describe.skip('reusability of keen-query objects', function () {
 	let baseResult;

--- a/test/reusability.test.js
+++ b/test/reusability.test.js
@@ -27,8 +27,8 @@ describe.skip('reusability of keen-query objects', function () {
 		const altered = kq.filter('user.uuid');
 		expect(altered).to.not.equal(kq);
 		return Promise.all([
-			altered.print('json'),
-			kq.print('json')
+			altered.print('matrix'),
+			kq.print('matrix')
 		]).then(res => {
 			expect(res[0]).to.not.deep.equal(res[1]);
 		})
@@ -38,8 +38,8 @@ describe.skip('reusability of keen-query objects', function () {
 		const altered = kq.reduce('avg');
 		expect(altered).to.not.equal(kq);
 		return Promise.all([
-			altered.print('json'),
-			kq.print('json')
+			altered.print('matrix'),
+			kq.print('matrix')
 		]).then(res => {
 			expect(res[0]).to.not.deep.equal(res[1]);
 		})
@@ -55,8 +55,8 @@ describe.skip('reusability of keen-query objects', function () {
 		});
 		it('should not mutate original ratio data when reducing', function () {
 			return Promise.all([
-				ratio.reduce('avg').print('json'),
-				ratio.print('json')
+				ratio.reduce('avg').print('matrix'),
+				ratio.print('matrix')
 			])
 				.then(res => {
 					expect(res[0]).to.not.deep.equal(res[1]);

--- a/test/url-generation.test.js
+++ b/test/url-generation.test.js
@@ -1,6 +1,10 @@
 'use strict';
 
 const KeenQuery = require('../lib');
+KeenQuery.setConfig({
+	KEEN_PROJECT_ID: 'test_proj',
+	KEEN_READ_KEY: 'test_key'
+});
 const expect = require('chai').expect;
 
 const queryUrlMappings = {


### PR DESCRIPTION
Breaking changes

1. `print('json')` is now `print('matrix')`
2. `getTable()` is now `getData()`. No longer intended for external use
3. `humanize()` is now `unflatten()`. No longer intended for external use
4. Apart from the cli, will not pick up config from environment/window. use `.setConfig()` and pass in an object
5. `forceQuery()`, which didn't work anyway, is now gone
6. `cutoff`, `top` and `bottom` now expect e.g. `cutoff(10%)` not `cutoff(10,percent)`
7. `sortProp()` is now `reorder()`
8. `CONCATENATION_RESULT` placeholder heading is now `_headings`
9. `reduce()` now expects e.g. `reduce(timeframe,avg)` rather than `reduce(avg,timeframe)`
10. new `getTable(type)` method, equivalent to `getTable().humanize(type)` in v2