### PR TITLE
added indentation helper

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const KeenQuery = require('./keen-query');
 const parser = require('./parser');
 const Aggregator = require('./aggregator');
@@ -36,3 +38,28 @@ module.exports.build = build;
 module.exports.execute = str => build(str).print();
 
 module.exports.parseFilter = parser.parseFilter;
+
+function stringifyFunctionConfigs (functions, indenter) {
+	return functions.map(func => {
+		const params = func.func === 'filter' ? parser.unparseFilter(func.params[0]) : func.params.join(',');
+		return `${indenter}->${func.func}(${params})`
+	});
+}
+
+module.exports.format = function format (str, indenter, isSingleLine) {
+
+	let lineBreak = '\n';
+	if (isSingleLine) {
+		lineBreak = indenter = '';
+	}
+	const tree = typeof str === 'object' ? str : parser(str);
+
+	if (tree.type === 'AggregateQuery') {
+		return `@${tree.aggregator}(${lineBreak}\
+${indenter}${tree.body.map(qs => format(qs, indenter, true)).join(`,${lineBreak}${indenter}`)}${lineBreak}\
+)${lineBreak}\
+${stringifyFunctionConfigs(tree.functions, indenter).join(lineBreak)}`
+	} else {
+		return `${tree.event}${lineBreak}${stringifyFunctionConfigs(tree.functions, indenter).join(lineBreak)}`
+	}
+}

--- a/lib/keen-query/index.js
+++ b/lib/keen-query/index.js
@@ -196,18 +196,9 @@ class KeenQuery {
 			str += `->group(${this.groupedBy.join(',')})`
 		}
 
-		this.filters.forEach(f => {
-			let filter;
-			if (f.operator === 'exists') {
-				filter = (f.property_value === false ? '!' : '') + f.property_name;
-			} else if (f.operator === 'in') {
-				filter = f.property_name + '?' + f.property_value.join(',');
-			} else {
-				filter = f.property_name + mappings.reverseFilterShorthands[f.operator] + f.property_value;
-			}
-
-			str += `->filter(${filter})`;
-		})
+		this.filters.forEach(filter => {
+			str += `->filter(${parser.unparseFilter(filter)})`
+		});
 
 		if (this.timeframe) {
 			try {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -52,6 +52,18 @@ function parseFilter (filter) {
 	throw new Error('Filter structure not recognised');
 }
 
+function unparseFilter (filterObj) {
+	let filter;
+	if (filterObj.operator === 'exists') {
+		filter = (filterObj.property_value === false ? '!' : '') + filterObj.property_name;
+	} else if (filterObj.operator === 'in') {
+		filter = filterObj.property_name + '?' + filterObj.property_value.join(',');
+	} else {
+		filter = filterObj.property_name + mappings.reverseFilterShorthands[filterObj.operator] + filterObj.property_value;
+	}
+
+	return filter;
+}
 
 function parseParams (params, func) {
 	if (typeof params === 'string') {
@@ -352,3 +364,4 @@ function parse (str) {
 
 module.exports = parse;
 module.exports.parseFilter = parseFilter;
+module.exports.unparseFilter = unparseFilter;


### PR DESCRIPTION
At the moment in query wizard the way we convert the entry in the textarea to urls / tidy it up / validate it is by using

string -> parser -> buildQuery -> toString -. put back in text area / url etc.

which gets us into a mess when using aggregate queries as there are lots of different strings  that will generate the same aggregate, and toString() generally goes for the most verbose

This helper cuts out the middleman, keeps higher fidelity between the string entered and the result, and gives greater control over how to format the string

string -> parser -> format

@adambraimbridge 